### PR TITLE
make send_event also pass EventData through to conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 dist
 dist/*
 *.egg-info
+*.iml
+.idea


### PR DESCRIPTION
Hey,

I've recently found that it would be useful if condition functions also had access to EventData (or args/kwargs) so that data can be passed through when triggering a transition to help determine whether the transition should succeed or not.

Here's a PR implementing this feature. Would appreciate it if you could take a look, thanks!