### PR TITLE
Create diagram from machine states and triggers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "3.4"
   - "3.3"
   - "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y graphviz
 install:
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 dill
+pygraphviz

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('transitions/version.py') as f:
 if len(set(('test', 'easy_install')).intersection(sys.argv)) > 0:
     import setuptools
 
-tests_require = ['dill']
+tests_require = ['dill', 'pygraphviz']
 
 extra_setuptools_args = {}
 if 'setuptools' in sys.modules:

--- a/tests/test_diagrams.py
+++ b/tests/test_diagrams.py
@@ -1,0 +1,35 @@
+try:
+    from builtins import object
+except ImportError:
+    pass
+
+from transitions import Machine, MachineError
+from unittest import TestCase
+import tempfile
+import os
+
+
+class TestDiagrams(TestCase):
+
+    def test_agraph_diagram(self):
+        states = ['A', 'B', 'C', 'D']
+        transitions = [
+            {'trigger': 'walk', 'source': 'A', 'dest': 'B'},
+            {'trigger': 'run', 'source': 'B', 'dest': 'C'},
+            {'trigger': 'sprint', 'source': 'C', 'dest': 'D'}
+        ]
+
+        m = Machine(states=states, transitions=transitions, initial='A')
+        graph = m.get_graph()
+
+        # check for a valid pygraphviz diagram
+        self.assertNotEquals(graph, None)
+        self.assertTrue("digraph" in str(graph))
+
+        # write diagram to temp file
+        target = tempfile.NamedTemporaryFile()
+        graph.draw(target.name, prog='dot')
+        self.assertTrue(os.path.getsize(target.name) > 0)
+
+        # cleanup temp file
+        target.close()

--- a/tests/test_diagrams.py
+++ b/tests/test_diagrams.py
@@ -23,7 +23,7 @@ class TestDiagrams(TestCase):
         graph = m.get_graph()
 
         # check for a valid pygraphviz diagram
-        self.assertNotEquals(graph, None)
+        self.assertIsNotNone(graph)
         self.assertTrue("digraph" in str(graph))
 
         # write diagram to temp file

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -464,8 +464,8 @@ class Machine(object):
         else:
             func(*event_data.args, **event_data.kwargs)
 
-    def get_graph(self, title=None):
-        return AGraph(self).get_graph(title)
+    def get_graph(self, title=None, diagram_class=AGraph):
+        return diagram_class(self).get_graph(title)
 
     def __getattr__(self, name):
         if name.startswith('__'):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -6,6 +6,7 @@ except ImportError:
 from functools import partial
 from collections import defaultdict, OrderedDict
 from six import string_types
+from .diagram import Diagram
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -462,6 +463,9 @@ class Machine(object):
             func(event_data)
         else:
             func(*event_data.args, **event_data.kwargs)
+
+    def get_graph(self, title=None):
+        return Diagram(self).get_graph(title)
 
     def __getattr__(self, name):
         if name.startswith('__'):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -6,7 +6,7 @@ except ImportError:
 from functools import partial
 from collections import defaultdict, OrderedDict
 from six import string_types
-from .diagram import Diagram
+from .diagrams import AGraph
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -465,7 +465,7 @@ class Machine(object):
             func(*event_data.args, **event_data.kwargs)
 
     def get_graph(self, title=None):
-        return Diagram(self).get_graph(title)
+        return AGraph(self).get_graph(title)
 
     def __getattr__(self, name):
         if name.startswith('__'):

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -47,7 +47,7 @@ class AGraph(Diagram):
             shape = self.state_attributes['shape']
 
             # We want the first state to be a double circle (UML style)
-            if state == self.machine.states.items()[0]:
+            if state == list(self.machine.states.items())[0]:
                 shape = 'doublecircle'
             else:
                 shape = self.state_attributes['shape']

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -5,13 +5,14 @@ class Diagram(object):
     def __init__(self, machine):
         self.machine = machine
 
-class AGraph(Diagram)
-    self.state_attributes = {
+
+class AGraph(Diagram):
+    state_attributes = {
         'shape': 'circle',
         'height': '1.2',
     }
 
-    self.machine_attributes = {
+    machine_attributes = {
         'directed': True,
         'strict': False,
         'rankdir': 'LR',
@@ -34,13 +35,13 @@ class AGraph(Diagram)
 
         # For each state, draw a circle
         for state in self.machine.states.items():
-            shape = state_attrs['shape']
+            shape = self.state_attributes['shape']
 
             # We want the first state to be a double circle (UML style)
             if state == self.machine.states.items()[0]:
                 shape = 'doublecircle'
             else:
-                shape = state_attrs['shape']
+                shape = self.state_attributes['shape']
 
             state = state[0]
             fsm_graph.add_node(n=state, shape=shape)

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -1,0 +1,62 @@
+import pygraphviz as pgv
+
+
+class Diagram(object):
+    def __init__(self, machine):
+        self.machine = machine
+
+class AGraph(Diagram)
+    self.state_attributes = {
+        'shape': 'circle',
+        'height': '1.2',
+    }
+
+    self.machine_attributes = {
+        'directed': True,
+        'strict': False,
+        'rankdir': 'LR',
+        'ratio': '0.3'
+    }
+
+    def get_graph(self, title=None):
+        """ Generate a DOT graph with pygraphviz, returns an AGraph object
+        Args:
+            title (string): Optional title for the graph.
+        """
+
+        if title is None:
+            title = self.__class__.__name__
+        elif title is False:
+            title = ''
+
+        fsm_graph = pgv.AGraph(title=title, **self.machine_attributes)
+        fsm_graph.node_attr.update(self.state_attributes)
+
+        # For each state, draw a circle
+        for state in self.machine.states.items():
+            shape = state_attrs['shape']
+
+            # We want the first state to be a double circle (UML style)
+            if state == self.machine.states.items()[0]:
+                shape = 'doublecircle'
+            else:
+                shape = state_attrs['shape']
+
+            state = state[0]
+            fsm_graph.add_node(n=state, shape=shape)
+
+        fsm_graph.add_node('null', shape='plaintext', label='')
+        fsm_graph.add_edge('null', 'new')
+
+        # For each event, add the transitions
+        for event in self.machine.events.items():
+            event = event[1]
+            label = str(event.name)
+
+            for transition in event.transitions.items():
+                src = transition[0]
+                dst = transition[1][0].dest
+
+                fsm_graph.add_edge(src, dst, label=label)
+
+        return fsm_graph

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -1,10 +1,17 @@
-import pygraphviz as pgv
+import abc
+try:
+    import pygraphviz as pgv
+except:
+    pgv = None
 
 
 class Diagram(object):
     def __init__(self, machine):
         self.machine = machine
 
+    @abc.abstractmethod
+    def get_graph(self):
+        return
 
 class AGraph(Diagram):
     state_attributes = {
@@ -24,6 +31,8 @@ class AGraph(Diagram):
         Args:
             title (string): Optional title for the graph.
         """
+        if not pgv:
+            raise Exception('AGraph diagram requires pygraphviz')
 
         if title is None:
             title = self.__class__.__name__


### PR DESCRIPTION
I've split up the graphs, so we can perhaps add different diagram types later on, not sure if we want that right now, but it's easier to scale out later on. The `Machine.get_graph()` method will return a pygraphviz object.

You can render a png like this:
```
In [7]: machine.get_graph().draw('foobar.png', prog='dot')
```
![Round Diagram](https://cloud.githubusercontent.com/assets/19777/11685345/98fd17fe-9e78-11e5-9c0f-1a878dc327f3.png)

Or you can render the dot markup directly to string:
```
In [8]: print machine.get_graph()
digraph {
	graph [rankdir=LR,
		ratio=0.3,
		title=AGraph
	];
	node [height=1.2,
		label="\N",
		shape=circle
	];
    ...
}
```

I defaulted to the AGraph diagram type, you can override or provide your own diagram classes by subclassing Diagram or in this case AGraph, eg for creating square images:

```
from transitions.diagrams import AGraph

class BlockAGraph(AGraph):
    state_attributes = {
        'shape': 'square',
        'height': '1.2',
    }

machine.get_graph(diagram_class=BlockAGraph).draw('foobar.png', prog='dot')
```
![Look mommy, squares!](https://cloud.githubusercontent.com/assets/19777/11685335/849a9aa2-9e78-11e5-9c95-4f433341ff71.png)