### PR TITLE
Locked(HSM) Fixes & Diagram Doublecircle

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ machine.to_C_3_a() # exit A, enter C, enter C_3, enter C_3_a
 
 ### Extension: Reuse of previously created HSMs
 
-Besides semantical order, nested states are very handy if you want to specify state machines for specific tasks and plan to reuse them. Transitions offers two ways to achieve this: You can either *pass a state machine* as an argument or retrieve the machine's *blueprint*, store this as plain text somewhere and pass this to a new machine.
+Besides semantic order, nested states are very handy if you want to specify state machines for specific tasks and plan to reuse them. Transitions offers two ways to achieve this: You can either *pass a state machine* as an argument or retrieve the machine's *blueprint*, store this as plain text somewhere and pass this to a new machine.
 
 ```python
 count_states = ['1', '2', '3', 'done']
@@ -697,7 +697,7 @@ count_trans = [
 counter = Machine(states=count_states, transitions=count_trans, initial='1')
 
 counter.increase() # love my counter
-counter.blueprints #  
+counter.blueprints
 >>> {'states': ['1', '2', '3', 'done'], 'transitions': [{'unless': None, 'dest': '2', 'after': None, 'source': '1', 'trigger': 'increase', 'conditions': None, 'before': None}, ...]}
 ...
 states = ['waiting', 'collecting', {'name': 'counting', children: counter}]
@@ -728,14 +728,14 @@ states = ['waiting', 'collecting', {'name': 'counting', children: counter, 'rema
 collector.increase() # counting_3
 collector.done()
 collector.state
->>> 'waiting' # be aware that 'finish will entirely be removed from the state machine
+>>> 'waiting' # be aware that 'finish' will entirely be removed from the state machine
 ```
 
 If a reused state machine does not have a final state, you can of course add the transitions manually. If 'counter' had no 'done' state, we could just add `['done', 'counter_3', 'A']` to achieve the same behaviour.
 
 ### <a name="threading"></a>Extension: Threadsafe(-ish) State Machine
 
-In cases where event dispatching is done in Threads, one can use either `LockedMachine` or `LockedHSM` where **function access** (!sic) is secured with reentrant locks. This does not save you from corrupting your machine by tinkering with member variables of your model or state machine.
+In cases where event dispatching is done in threads, one can use either `LockedMachine` or `LockedHierarchicalMachine` where **function access** (!sic) is secured with reentrant locks. This does not save you from corrupting your machine by tinkering with member variables of your model or state machine.
 
 ```python
 from transition import LockedMachine as Machine

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -47,3 +47,25 @@ class TestTransitions(TestCase):
         # we have to wait to be sure it is done
         time.sleep(1)
         self.assertEqual(self.stuff.state, "C")
+
+    def test_pickle(self):
+        import sys
+        if sys.version_info < (3, 4):
+            import dill as pickle
+        else:
+            import pickle
+
+        states = ['A', 'B', 'C', 'D']
+        # Define with list of dictionaries
+        transitions = [
+            {'trigger': 'walk', 'source': 'A', 'dest': 'B'},
+            {'trigger': 'run', 'source': 'B', 'dest': 'C'},
+            {'trigger': 'sprint', 'source': 'C', 'dest': 'D'}
+        ]
+        m = Machine(states=states, transitions=transitions, initial='A')
+        m.walk()
+        dump = pickle.dumps(m)
+        self.assertIsNotNone(dump)
+        m2 = pickle.loads(dump)
+        self.assertEqual(m.state, m2.state)
+        m2.run()

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -48,24 +48,25 @@ class TestTransitions(TestCase):
         time.sleep(1)
         self.assertEqual(self.stuff.state, "C")
 
-    def test_pickle(self):
-        import sys
-        if sys.version_info < (3, 4):
-            import dill as pickle
-        else:
-            import pickle
-
-        states = ['A', 'B', 'C', 'D']
-        # Define with list of dictionaries
-        transitions = [
-            {'trigger': 'walk', 'source': 'A', 'dest': 'B'},
-            {'trigger': 'run', 'source': 'B', 'dest': 'C'},
-            {'trigger': 'sprint', 'source': 'C', 'dest': 'D'}
-        ]
-        m = Machine(states=states, transitions=transitions, initial='A')
-        m.walk()
-        dump = pickle.dumps(m)
-        self.assertIsNotNone(dump)
-        m2 = pickle.loads(dump)
-        self.assertEqual(m.state, m2.state)
-        m2.run()
+    # # pickling test disabled due to issues with python >= 3.4, pickle and locks
+    # def test_pickle(self):
+    #     import sys
+    #     if sys.version_info < (3, 4):
+    #         import dill as pickle
+    #     else:
+    #         import pickle
+    #
+    #     states = ['A', 'B', 'C', 'D']
+    #     # Define with list of dictionaries
+    #     transitions = [
+    #         {'trigger': 'walk', 'source': 'A', 'dest': 'B'},
+    #         {'trigger': 'run', 'source': 'B', 'dest': 'C'},
+    #         {'trigger': 'sprint', 'source': 'C', 'dest': 'D'}
+    #     ]
+    #     m = Machine(states=states, transitions=transitions, initial='A')
+    #     m.walk()
+    #     dump = pickle.dumps(m)
+    #     self.assertIsNotNone(dump)
+    #     m2 = pickle.loads(dump)
+    #     self.assertEqual(m.state, m2.state)
+    #     m2.run()

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -33,8 +33,8 @@ class AGraph(Diagram):
         for state in states.keys():
             shape = self.state_attributes['shape']
 
-            # We want the first state to be a double circle (UML style)
-            if state == list(states.items())[0]:
+            # We want the initial state to be a double circle (UML style)
+            if state == self.machine._initial:
                 shape = 'doublecircle'
             else:
                 shape = self.state_attributes['shape']

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -23,18 +23,17 @@ class AAGraph(AGraph):
                 continue
             elif state.children is not None:
                 self.seen.append(state.name)
-                sub = container.add_subgraph(name="cluster_"+state.name, rank='same', label=state.name)
+                sub = container.add_subgraph(name="cluster_"+state.name, label=state.name)
                 self._add_nodes(state.children, sub)
             else:
-                # We want the first state to be a double circle (UML style)
-                if state == list(self.machine.states.items())[0]:
+                # We want the inital state to be a double circle (UML style)
+                if state.name == self.machine._initial:
                     shape = 'doublecircle'
                 else:
                     shape = self.state_attributes['shape']
 
                 state = state.name
                 self.seen.append(state)
-                shape = self.state_attributes['shape']
                 container.add_node(n=state, shape=shape)
 
     def _add_edges(self, events, sub):


### PR DESCRIPTION
Hi,

I fixed LockedHSM to use LockedNestedTranstions and fixed pickling issues for python 2.7.  I added a pickling test to test_threading. However, pickle does not support thread locks which means it fails now for python > 3 but dill does…

I also ‘fixed’ the double circle thing but could revert changes in `AGraph` and `AAGraph` since @wtgee is also working on it.