### PR TITLE
Fix for #59

### DIFF
--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -48,25 +48,41 @@ class TestTransitions(TestCase):
         time.sleep(1)
         self.assertEqual(self.stuff.state, "C")
 
-    # # pickling test disabled due to issues with python >= 3.4, pickle and locks
-    # def test_pickle(self):
-    #     import sys
-    #     if sys.version_info < (3, 4):
-    #         import dill as pickle
-    #     else:
-    #         import pickle
-    #
-    #     states = ['A', 'B', 'C', 'D']
-    #     # Define with list of dictionaries
-    #     transitions = [
-    #         {'trigger': 'walk', 'source': 'A', 'dest': 'B'},
-    #         {'trigger': 'run', 'source': 'B', 'dest': 'C'},
-    #         {'trigger': 'sprint', 'source': 'C', 'dest': 'D'}
-    #     ]
-    #     m = Machine(states=states, transitions=transitions, initial='A')
-    #     m.walk()
-    #     dump = pickle.dumps(m)
-    #     self.assertIsNotNone(dump)
-    #     m2 = pickle.loads(dump)
-    #     self.assertEqual(m.state, m2.state)
-    #     m2.run()
+    def test_pickle(self):
+        import sys
+        if sys.version_info < (3, 4):
+            import dill as pickle
+        else:
+            import pickle
+
+        # go to non initial state B
+        self.stuff.to_B()
+        # pickle Stuff model
+        dump = pickle.dumps(self.stuff)
+        self.assertIsNotNone(dump)
+        stuff2 = pickle.loads(dump)
+        self.assertTrue(stuff2.machine.is_state("B"))
+        # check if machines of stuff and stuff2 are truly separated
+        stuff2.to_A()
+        self.stuff.to_C()
+        self.assertTrue(stuff2.machine.is_state("A"))
+        thread = Thread(target=stuff2.process)
+        thread.start()
+        # give thread some time to start
+        time.sleep(0.01)
+        # both objects should be in different states
+        # and also not share locks
+        begin = time.time()
+        # stuff should not be locked and execute fast
+        self.assertTrue(self.stuff.machine.is_state("C"))
+        fast = time.time()
+        # stuff2 should be locked and take about 1 second
+        # to be executed
+        self.assertTrue(stuff2.machine.is_state("B"))
+        blocked = time.time()
+        self.assertAlmostEqual(fast-begin, 0, delta=0.1)
+        self.assertAlmostEqual(blocked-begin, 1, delta=0.1)
+
+
+
+

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -290,6 +290,16 @@ class HierarchicalMachine(Machine):
         return super(HierarchicalMachine, self).get_graph(title, diagram_class)
 
 
+class LockedMethod:
+    def __init__(self, lock, func):
+        self.lock = lock
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        with self.lock:
+            return self.func(*args, **kwargs)
+
+
 # lock access to methods of the state machine
 # can be used if threaded access to the state machine is required.
 class LockedMachine(Machine):
@@ -306,13 +316,11 @@ class LockedMachine(Machine):
         f = super(LockedMachine, self).__getattribute__
         tmp = f(item)
         if inspect.ismethod(tmp) and item not in "__getattribute__":
-            lock = f('lock')
-            def locked_method(*args, **kwargs):
-                with lock:
-                    res = f(item)(*args, **kwargs)
-                    return res
-            return locked_method
+            return LockedMethod(f('lock'), tmp)
         return tmp
+
+    def __getattr__(self, item):
+        return super(LockedMachine, self).__getattribute__(item)
 
 
 # Uses HSM as well as Mutex features


### PR DESCRIPTION
To be pickled
* objects should not be local
-> moved locked_method to callable object LockedMethod
* subclasses should not mess around with __getattribute__
-> Even though the method was found with __getattribute__, __getattr__
was called in pickle.load(). I assume this has something to do with the
order in which objects are deserialized. Overriding __getattr__ of the
subclass with __getattribute__ of the base class solves the issue.

I also expanded the pickle test in test_threading to check if locking still works after pickling.