### PR TITLE
Improved Testing & __getattr__ LockedMachine fix

### DIFF
--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -6,9 +6,11 @@ except ImportError:
 import time
 from threading import Thread
 
-from transitions import LockedHierarchicalMachine as Machine
+from transitions import LockedHierarchicalMachine
+from transitions import LockedMachine
+from .test_nesting import TestTransitions as TestsNested
+from .test_core import TestTransitions as TestCore
 from .utils import Stuff
-from unittest import TestCase
 
 try:
     from unittest.mock import MagicMock
@@ -20,10 +22,10 @@ def heavy_processing():
     time.sleep(1)
 
 
-class TestTransitions(TestCase):
+class TestLockedTransitions(TestCore):
 
     def setUp(self):
-        self.stuff = Stuff(machine_cls=Machine)
+        self.stuff = Stuff(machine_cls=LockedMachine)
         self.stuff.heavy_processing = heavy_processing
         self.stuff.machine.add_transition('process', '*', 'B', before='heavy_processing')
 
@@ -84,5 +86,58 @@ class TestTransitions(TestCase):
         self.assertAlmostEqual(blocked-begin, 1, delta=0.1)
 
 
+# Same as TestLockedTransition but with LockedHierarchicalMachine
+class TestLockedHierarchicalTransitions(TestsNested, TestLockedTransitions):
+    def setUp(self):
+        states = ['A', 'B', {'name': 'C', 'children': ['1', '2', {'name': '3', 'children': ['a', 'b', 'c']}]},
+          'D', 'E', 'F']
+        self.stuff = Stuff(states, machine_cls=LockedHierarchicalMachine)
+        self.stuff.heavy_processing = heavy_processing
+        self.stuff.machine.add_transition('process', '*', 'B', before='heavy_processing')
 
+    def test_parallel_access(self):
+        thread = Thread(target=self.stuff.process)
+        thread.start()
+        # give thread some time to start
+        time.sleep(0.01)
+        self.stuff.to_C()
+        # if 'process' has not been locked, it is still running
+        # we have to wait to be sure it is done
+        time.sleep(1)
+        self.assertEqual(self.stuff.state, "C_1")
+
+    def test_pickle(self):
+        import sys
+        if sys.version_info < (3, 4):
+            import dill as pickle
+        else:
+            import pickle
+
+        # go to non initial state B
+        self.stuff.to_B()
+        # pickle Stuff model
+        dump = pickle.dumps(self.stuff)
+        self.assertIsNotNone(dump)
+        stuff2 = pickle.loads(dump)
+        self.assertTrue(stuff2.machine.is_state("B"))
+        # check if machines of stuff and stuff2 are truly separated
+        stuff2.to_A()
+        self.stuff.to_C()
+        self.assertTrue(stuff2.machine.is_state("A"))
+        thread = Thread(target=stuff2.process)
+        thread.start()
+        # give thread some time to start
+        time.sleep(0.01)
+        # both objects should be in different states
+        # and also not share locks
+        begin = time.time()
+        # stuff should not be locked and execute fast
+        self.assertTrue(self.stuff.machine.is_state("C_1"))
+        fast = time.time()
+        # stuff2 should be locked and take about 1 second
+        # to be executed
+        self.assertTrue(stuff2.machine.is_state("B"))
+        blocked = time.time()
+        self.assertAlmostEqual(fast-begin, 0, delta=0.1)
+        self.assertAlmostEqual(blocked-begin, 1, delta=0.1)
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -48,25 +48,41 @@ class TestTransitions(TestCase):
         time.sleep(1)
         self.assertEqual(self.stuff.state, "C")
 
-    # # pickling test disabled due to issues with python >= 3.4, pickle and locks
-    # def test_pickle(self):
-    #     import sys
-    #     if sys.version_info < (3, 4):
-    #         import dill as pickle
-    #     else:
-    #         import pickle
-    #
-    #     states = ['A', 'B', 'C', 'D']
-    #     # Define with list of dictionaries
-    #     transitions = [
-    #         {'trigger': 'walk', 'source': 'A', 'dest': 'B'},
-    #         {'trigger': 'run', 'source': 'B', 'dest': 'C'},
-    #         {'trigger': 'sprint', 'source': 'C', 'dest': 'D'}
-    #     ]
-    #     m = Machine(states=states, transitions=transitions, initial='A')
-    #     m.walk()
-    #     dump = pickle.dumps(m)
-    #     self.assertIsNotNone(dump)
-    #     m2 = pickle.loads(dump)
-    #     self.assertEqual(m.state, m2.state)
-    #     m2.run()
+    def test_pickle(self):
+        import sys
+        if sys.version_info < (3, 4):
+            import dill as pickle
+        else:
+            import pickle
+
+        # go to non initial state B
+        self.stuff.to_B()
+        # pickle Stuff model
+        dump = pickle.dumps(self.stuff)
+        self.assertIsNotNone(dump)
+        stuff2 = pickle.loads(dump)
+        self.assertTrue(stuff2.machine.is_state("B"))
+        # check if machines of stuff and stuff2 are truly separated
+        stuff2.to_A()
+        self.stuff.to_C()
+        self.assertTrue(stuff2.machine.is_state("A"))
+        thread = Thread(target=stuff2.process)
+        thread.start()
+        # give thread some time to start
+        time.sleep(0.01)
+        # both objects should be in different states
+        # and also not share locks
+        begin = time.time()
+        # stuff should not be locked and execute fast
+        self.assertTrue(self.stuff.machine.is_state("C"))
+        fast = time.time()
+        # stuff2 should be locked and take about 1 second
+        # to be executed
+        self.assertTrue(stuff2.machine.is_state("B"))
+        blocked = time.time()
+        self.assertAlmostEqual(fast-begin, 0, delta=0.1)
+        self.assertAlmostEqual(blocked-begin, 1, delta=0.1)
+
+
+
+

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -49,11 +49,11 @@ class AGraph(Diagram):
             event = event[1]
             label = str(event.name)
 
-            for transition in event.transitions.items():
-                src = transition[0]
-                dst = transition[1][0].dest
-
-                container.add_edge(src, dst, label=label)
+            for transitions in event.transitions.items():
+                src = transitions[0]
+                for t in transitions[1]:
+                    dst = t.dest
+                    container.add_edge(src, dst, label=label)
 
     def get_graph(self, title=None):
         """ Generate a DOT graph with pygraphviz, returns an AGraph object

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -290,6 +290,16 @@ class HierarchicalMachine(Machine):
         return super(HierarchicalMachine, self).get_graph(title, diagram_class)
 
 
+class LockedMethod:
+    def __init__(self, lock, func):
+        self.lock = lock
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        with self.lock:
+            return self.func(*args, **kwargs)
+
+
 # lock access to methods of the state machine
 # can be used if threaded access to the state machine is required.
 class LockedMachine(Machine):
@@ -306,13 +316,11 @@ class LockedMachine(Machine):
         f = super(LockedMachine, self).__getattribute__
         tmp = f(item)
         if inspect.ismethod(tmp) and item not in "__getattribute__":
-            lock = f('lock')
-            def locked_method(*args, **kwargs):
-                with lock:
-                    res = f(item)(*args, **kwargs)
-                    return res
-            return locked_method
+            return LockedMethod(f('lock'), tmp)
         return tmp
+
+    def __getattr__(self, item):
+        return super(LockedMachine, self).__getattribute__(item)
 
 
 # Uses HSM as well as Mutex features

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -44,15 +44,15 @@ class AAGraph(AGraph):
             event = event[1]
             label = str(event.name)
 
-            for transition in event.transitions.items():
-                src = transition[0]
-                dst = self.machine.get_state(transition[1][0].dest)
-                if dst.children is not None:
-                    dst = dst.get_initial().name
-                else:
-                    dst = dst.name
-
-                sub.add_edge(src, dst, label=label)
+            for transitions in event.transitions.items():
+                src = transitions[0]
+                for t in transitions[1]:
+                    dst = self.machine.get_state(t.dest)
+                    if dst.children is not None:
+                        dst = dst.get_initial().name
+                    else:
+                        dst = dst.name
+                    sub.add_edge(src, dst, label=label)
 
 
 # Added parent and children parameter children is a list of NestedStates

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -206,8 +206,10 @@ class HierarchicalMachine(Machine):
                     self._buffered_transitions.append((trans['trigger'], source, dest, trans.get('conditions', None),
                                                        trans.get('unless', None), trans.get('before', None),
                                                        trans.get('after', None)))
-            else:
+            elif isinstance(state, NestedState):
                 tmp_states.append(state)
+                if state.children:
+                    tmp_states.extend(self._flatten(state.children))
             new_states.extend(tmp_states)
         return new_states
 
@@ -227,10 +229,13 @@ class HierarchicalMachine(Machine):
                       'ignore_invalid_triggers': state.ignore_invalid_triggers}
                 if state.children is not None:
                     bp['children'] = self._to_blueprint(state.children)
-            elif isinstance(state, HierarchicalMachine):
-                if len(blueprints) > 0:
-                    raise ValueError
+            elif isinstance(state, Machine):
+                # this happens if there
+                if len(states) > 1:
+                    raise ValueError("States arrays and nested machines cannot be mixed!")
                 return state.blueprints['states']
+            else:
+                raise ValueError('Do not know state of type %s' % type(state))
 
             blueprints.append(bp)
         return blueprints
@@ -261,13 +266,9 @@ class HierarchicalMachine(Machine):
             bp_before = None
             bp_after = None
             if self.before_state_change:
-                bp_before = listify(self.before_state_change)
-                bp_before.extend(listify(before))
-                bp_before = unify(bp_before)
+                bp_before = listify(before) + listify(self.before_state_change)
             if self.after_state_change:
-                bp_after = listify(after)
-                bp_after.extend(listify(self.after_state_change))
-                bp_after = unify(bp_after)
+                bp_after = listify(after) + listify(self.after_state_change)
             self.blueprints['transitions'].append({'trigger': trigger, 'source': source, 'dest': dest,
                                                    'conditions': conditions, 'unless': unless, 'before': bp_before,
                                                    'after': bp_after})
@@ -320,7 +321,10 @@ class LockedMachine(Machine):
         return tmp
 
     def __getattr__(self, item):
-        return super(LockedMachine, self).__getattribute__(item)
+        try:
+            return super(LockedMachine, self).__getattribute__(item)
+        except AttributeError:
+            return super(LockedMachine, self).__getattr__(item)
 
 
 # Uses HSM as well as Mutex features
@@ -332,17 +336,3 @@ class LockedHierarchicalMachine(LockedMachine, HierarchicalMachine):
     @staticmethod
     def _create_transition(*args, **kwargs):
         return LockedNestedTransition(*args, **kwargs)
-
-
-# helper functions to filter duplicates in transition functions
-def unify(seq):
-    return list(_unify(seq))
-
-
-def _unify(seq):
-    seen = set()
-    for x in seq:
-        if x in seen:
-            continue
-        seen.add(x)
-        yield x


### PR DESCRIPTION
To reduce redundancy I let test_nesting and test_threading inherit from `TestTransitions` in test_core. This way I stumbled upon a bug in `LockedMachine.__getattr__`. I assumed `__getattribute__` will call `__getattr__` implicitely if it fails to find the item. But that does not seem to be the case. LockedMachine causes an `AttributeError` for         Machine.on_enter_State
Calling `super.__getattr__` as a fallback solves this issue.