### PR TITLE
Change some log messages' level from info to debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,14 +605,14 @@ Here you get to consolidate all state machine functionality into your existing m
 
 ### Logging
 
-Transitions includes very rudimentary logging capabilities. A number of events--namely, state changes, transition triggers, and conditional checks--are logged as INFO-level events using the standard Python `logging` module. This means you can easily configure logging to standard output in a script:
+Transitions includes very rudimentary logging capabilities. A number of events -- namely, state changes, transition triggers, and conditional checks -- are logged using the standard Python `logging` module (with different log levels). This means you can easily configure logging to standard output in a script:
 
 ```python
 
 # Set up logging
 import logging
 from transitions import logger
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.INFO)  # logging.DEBUG for verbosity
 
 # Business as usual
 machine = Machine(states=states, transitions=transitions, initial='solid')

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -48,14 +48,14 @@ class State(object):
         for oe in self.on_enter:
             event_data.machine.callback(
                 getattr(event_data.model, oe), event_data)
-        logger.info("Entered state %s" % self.name)
+        logger.debug("Entered state %s" % self.name)
 
     def exit(self, event_data):
         """ Triggered when a state is exited. """
         for oe in self.on_exit:
             event_data.machine.callback(
                 getattr(event_data.model, oe), event_data)
-        logger.info("Exited state %s" % self.name)
+        logger.debug("Exited state %s" % self.name)
 
     def add_callback(self, trigger, func):
         """ Add a new enter or exit callback.
@@ -127,23 +127,25 @@ class Transition(object):
         Args:
             event: An instance of class EventData.
         """
-        logger.info("Initiating transition from state %s to state %s...",
-                    self.source, self.dest)
+        logger.debug("Initiating transition from state %s to state %s...",
+                     self.source, self.dest)
         machine = event_data.machine
         for c in self.conditions:
             if not c.check(event_data):
-                logger.info("Transition condition failed: %s() does not " +
-                            "return %s. Transition halted.", c.func, c.target)
+                logger.error("Transition condition failed: %s() does not " +
+                             "return %s. Transition halted.", c.func, c.target)
                 return False
         for func in self.before:
             machine.callback(getattr(event_data.model, func), event_data)
-            logger.info("Executing callback '%s' before transition." % func)
+            logger.debug("Executing callback '%s' before transition." % func)
 
         self._change_state(event_data)
 
         for func in self.after:
             machine.callback(getattr(event_data.model, func), event_data)
-            logger.info("Executed callback '%s' after transition." % func)
+            logger.debug("Executed callback '%s' after transition." % func)
+        logger.info("Transitioned from state %s to state %s",
+                    self.source, self.dest)
         return True
 
     def _change_state(self, event_data):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -226,7 +226,7 @@ class Event(object):
             msg = "Can't trigger event %s from state %s!" % (self.name,
                                                              state_name)
             if self.machine.current_state.ignore_invalid_triggers:
-                logging.warning(msg)
+                logger.warning(msg)
             else:
                 raise MachineError(msg)
         event = EventData(self.machine.current_state, self, self.machine,


### PR DESCRIPTION
Reduces the amount of logging a bit. Especially useful when transitions is used together with another module that has its own logging.