### PR TITLE
Dynamic diagram nodes & edges

### DIFF
--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -70,7 +70,50 @@ class TestDiagrams(TestCase):
         for t in triggers:
             self.assertIsNotNone(getattr(m, t))
 
-        self.assertEqual(len(graph.edges()), 8) # see above
+        self.assertEqual(len(graph.edges()), 8)  # see above
+
+        # write diagram to temp file
+        target = tempfile.NamedTemporaryFile()
+        graph.draw(target.name, prog='dot')
+        self.assertTrue(os.path.getsize(target.name) > 0)
+
+        # cleanup temp file
+        target.close()
+
+    def test_store_nested_agraph_diagram(self):
+        ''' Same as above, but with nested states. '''
+        states = ['A', 'B', {'name': 'C', 'children': ['1', '2', '3']}, 'D']
+        transitions = [
+            {'trigger': 'walk', 'source': 'A', 'dest': 'B'},   # 1 edge
+            {'trigger': 'run', 'source': 'B', 'dest': 'C'},    # + 1 edge
+            {'trigger': 'sprint', 'source': 'C', 'dest': 'D',  # + 3 edges
+             'conditions': 'is_fast'},
+            {'trigger': 'sprint', 'source': 'C', 'dest': 'B'}  # + 3 edges = 8 edges
+        ]
+
+        m = HierarchicalMachine(
+            states=states, transitions=transitions, initial='A', auto_transitions=False, with_graph=True)
+        graph = m.get_graph()
+        self.assertIsNotNone(graph)
+        self.assertTrue("digraph" in str(graph))
+
+        # Test that graph properties match the Machine
+        # print((set(m.states.keys()), )
+        node_names = set([n.name for n in graph.nodes()])
+        self.assertEqual(set(m.states.keys()) - set('C'), node_names)
+
+        triggers = set([n.attr['label'] for n in graph.edges()])
+        for t in triggers:
+            self.assertIsNotNone(getattr(m, t))
+
+        self.assertEqual(len(graph.edges()), 8)  # see above
+
+        # Force a new
+        graph2 = m.get_graph(title="Second Graph", force_new=True)
+        self.assertIsNotNone(graph)
+        self.assertTrue("digraph" in str(graph))
+
+        self.assertFalse(graph == graph2)
 
         # write diagram to temp file
         target = tempfile.NamedTemporaryFile()

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -323,6 +323,7 @@ class Machine(object):
         if ordered_transitions:
             self.add_ordered_transitions()
 
+        self._graph = None
         if with_graph:
             self._graph = self.get_graph(title="State Machine")
 
@@ -492,8 +493,11 @@ class Machine(object):
         else:
             func(*event_data.args, **event_data.kwargs)
 
-    def get_graph(self, title=None, diagram_class=AGraph):
-        return diagram_class(self).get_graph(title)
+    def get_graph(self, title=None, force_new=False, diagram_class=AGraph):
+        if self._graph is None or force_new:
+            self._graph = diagram_class(self).get_graph(title)
+
+        return self._graph
 
     def set_edge_state(self, edge_from, edge_to, state='default'):
         """ Mark a node as active by changing the attributes """

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -324,7 +324,7 @@ class Machine(object):
             self.add_ordered_transitions()
 
         if with_graph:
-            self._graph = self.get_graph()
+            self._graph = self.get_graph(title="State Machine")
 
     @staticmethod
     def _create_transition(*args, **kwargs):

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -16,30 +16,19 @@ class Diagram(object):
 
 
 class AGraph(Diagram):
-    state_attributes = {
+    default_state_attributes = {
         'shape': 'circle',
         'height': '1.2',
-    }
-
-    machine_attributes = {
-        'directed': True,
-        'strict': False,
-        'rankdir': 'LR',
-        'ratio': '0.3'
+        'style': 'filled',
+        'fillcolor': 'white',
+        'color': 'black',
     }
 
     def _add_nodes(self, states, container, initial_state=None):
         # For each state, draw a circle
         for state in states.keys():
 
-            if initial_state is None:
-                initial_state = self.machine._initial
-
-            # We want the initial state to be a double circle (UML style)
-            if state == initial_state:
-                shape = 'doublecircle'
-            else:
-                shape = self.state_attributes['shape']
+            shape = self.default_state_attributes['shape']
 
             container.add_node(n=state, shape=shape)
 
@@ -69,7 +58,7 @@ class AGraph(Diagram):
             title = ''
 
         fsm_graph = pgv.AGraph(label=title, **self.machine_attributes)
-        fsm_graph.node_attr.update(self.state_attributes)
+        fsm_graph.node_attr.update(self.default_state_attributes)
 
         # For each state, draw a circle
         self._add_nodes(self.machine.states, fsm_graph)

--- a/transitions/diagrams.py
+++ b/transitions/diagrams.py
@@ -24,6 +24,13 @@ class AGraph(Diagram):
         'color': 'black',
     }
 
+    machine_attributes = {
+        'directed': True,
+        'strict': False,
+        'rankdir': 'LR',
+        'ratio': '0.3'
+    }
+
     def _add_nodes(self, states, container, initial_state=None):
         # For each state, draw a circle
         for state in states.keys():

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -283,11 +283,15 @@ class HierarchicalMachine(Machine):
         super(HierarchicalMachine, self).add_transition(trigger, source, dest, conditions=conditions,
                                                         unless=unless, before=before, after=after)
 
-    def get_graph(self, title=None, diagram_class=AAGraph):
-        return super(HierarchicalMachine, self).get_graph(title, diagram_class)
+    def get_graph(self, title=None, force_new=False, diagram_class=AAGraph):
+        if self._graph is None or force_new:
+            self._graph = super(HierarchicalMachine, self).get_graph(title, diagram_class)
+
+        return self._graph
 
 
 class LockedMethod:
+
     def __init__(self, lock, func):
         self.lock = lock
         self.func = func

--- a/transitions/extensions.py
+++ b/transitions/extensions.py
@@ -15,7 +15,7 @@ logger.addHandler(logging.NullHandler())
 class AAGraph(AGraph):
     seen = []
 
-    def _add_nodes(self, states, container, initial_state=None):
+    def _add_nodes(self, states, container):
         # to be able to process children recursively as well as the state dict of a machine
         states = states.values() if isinstance(states, dict) else states
         for state in states:
@@ -26,14 +26,7 @@ class AAGraph(AGraph):
                 sub = container.add_subgraph(name="cluster_" + state.name, label=state.name)
                 self._add_nodes(state.children, sub)
             else:
-                if initial_state is None:
-                    initial_state = self.machine._initial
-
-                # We want the inital state to be a double circle (UML style)
-                if state.name == initial_state:
-                    shape = 'doublecircle'
-                else:
-                    shape = self.state_attributes['shape']
+                shape = self.default_state_attributes['shape']
 
                 state = state.name
                 self.seen.append(state)


### PR DESCRIPTION
This adds the ability to store the graph object along with the machine so that it can be updated dynamically. Two public methods are provided to update the nodes and the edges. Three state styles added.

Example of how to add auto-update to model class:
```python
def __init__(self):
        Machine.__init__(
            self,
            states=_states,
            transitions=_transitions,
            initial=_initial
            send_event=True,
            before_state_change='before_state',
            with_graph=True,
        )

        self._previous_state = None
        self._next_state = None
        self._update_graph(with_previous=False)

def before_state(self, event_data):
    """ Called before each state.   """
    self._next_state = event_data.event.transitions.get(self.state)[0].dest
    self._previous_state = event_data.state.name
    self._update_graph()

def _update_graph(self, with_previous=True):
    """ Show the active state on the graph """
    if self._next_state is None:
        self._next_state = self.state

    # Mark the active node
    self.set_node_state(self._next_state, state='active', reset=True)

    # Mark the previous node and path used
    if with_previous:
        if self._previous_state is not None:
                self.set_node_state(self._previous_state, state='previous')
                self.set_edge_state(self._previous_state, self._next_state, state='previous')
```


* `Machine` option to store the graph
* `set_node_state` and `set_edge_state` work with stored graph to update
    appearance.
* Added 'default', 'active', and 'previous' state attributes