### PR TITLE
"prepare" callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,39 @@ lump.evaporate()
 >>> "where'd all the liquid go?"
 ```
 
+There is also a `'prepare'` callback that is executed as soon as the trigger runs, before any `'conditions'` are checked:
+
+```python
+class Matter(object):
+    heat = False
+    attempts = 0
+    def count_attempts(self): self.attempts += 1
+    def is_really_hot(self): return self.heat
+    def heat_up(self): self.heat = random.random() < 0.25
+    def stats(self): print('It took you %i attempts to melt the lump!' %self.attempts)
+
+states=['solid', 'liquid', 'gas', 'plasma']
+
+transitions = [
+    { 'trigger': 'melt', 'source': 'solid', 'dest': 'liquid', 'prepare': ['heat_up', 'count_attempts'], 'conditions': 'is_really_hot', 'after': 'stats'},
+]
+
+lump = Matter()
+machine = Machine(lump, states, transitions=transitions, initial='solid')
+lump.melt()
+lump.melt()
+lump.melt()
+lump.melt()
+>>> "It took you 4 attempts to melt the lump!"
+```
+
+In summary, callbacks on transitions are executed in the following order:
+
+* `'prepare'` (executed as soon as the trigger is called)
+* `'conditions'` / `'unless'` (conditions *may* fail and halt the transition)
+* `'before'` (executed while the model is still in the source state)
+* `'after'` (executed while the model is in the destination state)
+
 ### Passing data
 Sometimes you need to pass the callback functions registered at machine initialization some data that reflects the model's current state. Transitions allows you to do this in two different ways. 
 

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ lump.evaporate()
 >>> "where'd all the liquid go?"
 ```
 
-There is also a `'prepare'` callback that is executed as soon as the trigger runs, before any `'conditions'` are checked:
+There is also a `'prepare'` callback that is executed as soon as a transition starts, before any `'conditions'` are checked or other callbacks are executed.
 
 ```python
 class Matter(object):
@@ -520,9 +520,11 @@ lump.melt()
 >>> "It took you 4 attempts to melt the lump!"
 ```
 
+Note that if the transition is not valid from the current state, or there are multiple transitions sharing a trigger, `'prepare'` will only be called on the ones that are actually executed.
+
 In summary, callbacks on transitions are executed in the following order:
 
-* `'prepare'` (executed as soon as the trigger is called)
+* `'prepare'` (executed as soon as the transition starts)
 * `'conditions'` / `'unless'` (conditions *may* fail and halt the transition)
 * `'before'` (executed while the model is still in the source state)
 * `'after'` (executed while the model is in the destination state)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -369,3 +369,131 @@ class TestTransitions(TestCase):
         m2 = pickle.loads(dump)
         self.assertEqual(m.state, m2.state)
         m2.run()
+
+    def test___getattr___and_identify_callback(self):
+        m = Machine(Stuff(), states=['A', 'B', 'C'], initial='A')
+        m.add_transition('move', 'A', 'B')
+        m.add_transition('move', 'B', 'C')
+
+        callback = m.__getattr__('before_move')
+        self.assertTrue(callable(callback))
+
+        with self.assertRaises(MachineError):
+            m.__getattr__('before_no_such_transition')
+
+        with self.assertRaises(MachineError):
+            m.__getattr__('before_no_such_transition')
+
+        with self.assertRaises(AttributeError):
+            m.__getattr__('__no_such_method__')
+
+        with self.assertRaises(AttributeError):
+            m.__getattr__('')
+
+        type, target = m._identify_callback('on_exit_foobar')
+        self.assertEqual(type, 'on_exit')
+        self.assertEqual(target, 'foobar')
+
+        type, target = m._identify_callback('on_exitfoobar')
+        self.assertEqual(type, None)
+        self.assertEqual(target, None)
+
+        type, target = m._identify_callback('notacallback_foobar')
+        self.assertEqual(type, None)
+        self.assertEqual(target, None)
+
+        type, target = m._identify_callback('totallyinvalid')
+        self.assertEqual(type, None)
+        self.assertEqual(target, None)
+
+        type, target = m._identify_callback('before__foobar')
+        self.assertEqual(type, 'before')
+        self.assertEqual(target, '_foobar')
+
+        type, target = m._identify_callback('before__this__user__likes__underscores___')
+        self.assertEqual(type, 'before')
+        self.assertEqual(target, '_this__user__likes__underscores___')
+
+        type, target = m._identify_callback('before_stuff')
+        self.assertEqual(type, 'before')
+        self.assertEqual(target, 'stuff')
+
+        type, target = m._identify_callback('before_trailing_underscore_')
+        self.assertEqual(type, 'before')
+        self.assertEqual(target, 'trailing_underscore_')
+
+        type, target = m._identify_callback('before_')
+        self.assertIs(type, None)
+        self.assertIs(target, None)
+
+        type, target = m._identify_callback('__')
+        self.assertIs(type, None)
+        self.assertIs(target, None)
+
+        type, target = m._identify_callback('')
+        self.assertIs(type, None)
+        self.assertIs(target, None)
+
+    def test_state_and_transition_with_underscore(self):
+        m = Machine(Stuff(), states=['_A_', '_B_', '_C_'], initial='_A_')
+        m.add_transition('_move_', '_A_', '_B_', prepare='increase_level')
+        m.add_transition('_after_', '_B_', '_C_', prepare='increase_level')
+        m.add_transition('_on_exit_', '_C_', '_A_', prepare='increase_level', conditions='this_fails')
+
+        m.model._move_()
+        self.assertEquals(m.model.state, '_B_')
+        self.assertEquals(m.model.level, 2)
+
+        m.model._after_()
+        self.assertEquals(m.model.state, '_C_')
+        self.assertEquals(m.model.level, 3)
+
+        # State does not advance, but increase_level still runs
+        m.model._on_exit_()
+        self.assertEquals(m.model.state, '_C_')
+        self.assertEquals(m.model.level, 4)
+
+    def test_callback_identification(self):
+        m = Machine(Stuff(), states=['A', 'B', 'C', 'D', 'E', 'F'], initial='A')
+        m.add_transition('transition', 'A', 'B', before='increase_level')
+        m.add_transition('after', 'B', 'C', before='increase_level')
+        m.add_transition('on_exit_A', 'C', 'D', before='increase_level', conditions='this_fails')
+        m.add_transition('check', 'C', 'E', before='increase_level')
+        m.add_transition('prepare', 'E', 'F', before='increase_level')
+        m.add_transition('before', 'F', 'A', before='increase_level')
+
+        m.before_transition('increase_level')
+        m.before_after('increase_level')
+        m.before_on_exit_A('increase_level')
+        m.after_check('increase_level')
+        m.before_prepare('increase_level')
+        m.before_before('increase_level')
+
+        m.model.transition()
+        self.assertEquals(m.model.state, 'B')
+        self.assertEquals(m.model.level, 3)
+
+        m.model.after()
+        self.assertEquals(m.model.state, 'C')
+        self.assertEquals(m.model.level, 5)
+
+        m.model.on_exit_A()
+        self.assertEquals(m.model.state, 'C')
+        self.assertEquals(m.model.level, 5)
+
+        m.model.check()
+        self.assertEquals(m.model.state, 'E')
+        self.assertEquals(m.model.level, 7)
+
+        m.model.prepare()
+        self.assertEquals(m.model.state, 'F')
+        self.assertEquals(m.model.level, 9)
+
+        m.model.before()
+        self.assertEquals(m.model.state, 'A')
+        self.assertEquals(m.model.level, 11)
+
+        # An invalid transition shouldn't execute the callback
+        with self.assertRaises(MachineError):
+                m.model.on_exit_A()
+

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -535,14 +535,8 @@ class Machine(object):
                 state = self.get_state(target)
                 return partial(state.add_callback, callback_type[3:])
 
-            else:
-                raise AttributeError("{} does not exist".format(name))
-
-        else:
-            if name in self.__dict__:
-                return self.__dict__[name]
-            else:
-                raise AttributeError("{} does not exist".format(name))
+        # Nothing matched
+        raise AttributeError("{} does not exist".format(name))
 
 
 class MachineError(Exception):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -256,6 +256,10 @@ class Event(object):
 
 class Machine(object):
 
+    # Callback naming parameters
+    callbacks = ['before', 'after', 'prepare', 'on_enter', 'on_exit']
+    separator = '_'
+
     def __init__(self, model=None, states=None, initial=None, transitions=None,
                  send_event=False, auto_transitions=True,
                  ordered_transitions=False, ignore_invalid_triggers=None,
@@ -494,22 +498,19 @@ class Machine(object):
         else:
             func(*event_data.args, **event_data.kwargs)
 
-    @staticmethod
-    def _identify_callback(name):
-        callbacks = ['before', 'after', 'prepare', 'on_enter', 'on_exit']
-        separator = '_'
-
+    @classmethod
+    def _identify_callback(cls, name):
         # Does the prefix match a known callback?
         try:
-            callback_type = callbacks[[name.find(x) for x in callbacks].index(0)]
+            callback_type = cls.callbacks[[name.find(x) for x in cls.callbacks].index(0)]
         except ValueError:
             return None, None
 
         # Extract the target by cutting the string after the type and separator
-        target = name[len(callback_type) + len(separator):]
+        target = name[len(callback_type) + len(cls.separator):]
 
         # Make sure there is actually a target to avoid index error and enforce _ as a separator
-        if target == '' or name[len(callback_type)] != separator:
+        if target == '' or name[len(callback_type)] != cls.separator:
             return None, None
 
         return callback_type, target

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -494,22 +494,49 @@ class Machine(object):
         else:
             func(*event_data.args, **event_data.kwargs)
 
+    @staticmethod
+    def _identify_callback(name):
+        callbacks = ['before', 'after', 'prepare', 'on_enter', 'on_exit']
+        separator = '_'
+
+        # Does the prefix match a known callback?
+        try:
+            callback_type = callbacks[[name.find(x) for x in callbacks].index(0)]
+        except ValueError:
+            return None, None
+
+        # Extract the target by cutting the string after the type and separator
+        target = name[len(callback_type) + len(separator):]
+
+        # Make sure there is actually a target to avoid index error and enforce _ as a separator
+        if target == '' or name[len(callback_type)] != separator:
+            return None, None
+
+        return callback_type, target
+
     def __getattr__(self, name):
         if name.startswith('__'):
             if name in self.__dict__:
                 return self.__dict__[name]
             else:
                 raise AttributeError("{} does not exist".format(name))
-        terms = name.split('_')
-        if terms[0] in ['before', 'after', 'prepare']:
-            name = '_'.join(terms[1:])
-            if name not in self.events:
-                raise MachineError('Event "%s" is not registered.' % name)
-            return partial(self.events[name].add_callback, terms[0])
 
-        elif name.startswith('on_enter') or name.startswith('on_exit'):
-            state = self.get_state('_'.join(terms[2:]))
-            return partial(state.add_callback, terms[1])
+        # Could be a callback
+        callback_type, target = self._identify_callback(name)
+
+        if callback_type is not None:
+            if callback_type in ['before', 'after', 'prepare']:
+                if target not in self.events:
+                    raise MachineError('Event "%s" is not registered.' % target)
+                return partial(self.events[target].add_callback, callback_type)
+
+            elif callback_type in ['on_enter', 'on_exit']:
+                state = self.get_state(target)
+                return partial(state.add_callback, callback_type[3:])
+
+            else:
+                raise AttributeError("{} does not exist".format(name))
+
         else:
             if name in self.__dict__:
                 return self.__dict__[name]

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -206,15 +206,16 @@ class HierarchicalMachine(Machine):
     def add_transition(self, trigger, source, dest, conditions=None,
                        unless=None, before=None, after=None, prepare=None):
         if not (trigger.startswith('to_') and source == '*'):
-            bp_before = None
-            bp_after = None
+            bp_prepare = prepare
+            bp_before = before
+            bp_after = after
             if self.before_state_change:
                 bp_before = listify(before) + listify(self.before_state_change)
             if self.after_state_change:
                 bp_after = listify(after) + listify(self.after_state_change)
             self.blueprints['transitions'].append({'trigger': trigger, 'source': source, 'dest': dest,
-                                                   'conditions': conditions, 'unless': unless, 'before': bp_before,
-                                                   'after': bp_after})
+                                                   'conditions': conditions, 'unless': unless, 'prepare': bp_prepare,
+                                                   'before': bp_before, 'after': bp_after})
         if isinstance(source, string_types):
             source = [x.name for x in self.states.values() if x.children is None] \
                 if source == '*' else [source]
@@ -229,5 +230,5 @@ class HierarchicalMachine(Machine):
                 source.extend(self._traverse_nested(state.children))
 
         super(HierarchicalMachine, self).add_transition(trigger, source, dest, conditions=conditions,
-                                                        unless=unless, before=before, after=after)
+                                                        unless=unless, prepare=prepare, before=before, after=after)
 

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -204,7 +204,7 @@ class HierarchicalMachine(Machine):
         return names
 
     def add_transition(self, trigger, source, dest, conditions=None,
-                       unless=None, before=None, after=None):
+                       unless=None, before=None, after=None, prepare=None):
         if not (trigger.startswith('to_') and source == '*'):
             bp_before = None
             bp_after = None


### PR DESCRIPTION
There seemed to be something of a consensus forming in #40, so I've continued with the changes I've already made by renaming the 'action' callback to 'before_check'.

I've also added some compatibility code, which is maybe a bit coarse but should work to keep older code working.

Reworking __getattr__ was a little annoying, but it didn't correctly handle underscores.

I'm not 100% certain this is ready to be merged, I'm just soliciting feedback at the moment.