### PR TITLE
diagrams: show conditions on edge labels

### DIFF
--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -32,7 +32,7 @@ class TestDiagrams(TestCase):
             set(m.states.keys()), set([n.name for n in graph.nodes()]))
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
-            t = t.split(AGraph.trigger_condition_sep)[0]
+            t = AGraph.edge_label_from_transition_label(t)
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), len(transitions))
@@ -71,7 +71,7 @@ class TestDiagrams(TestCase):
 
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
-            t = t.split(AGraph.trigger_condition_sep)[0]
+            t = AGraph.edge_label_from_transition_label(t)
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), 8)  # see above
@@ -111,7 +111,7 @@ class TestDiagrams(TestCase):
 
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
-            t = t.split(AGraph.trigger_condition_sep)[0]
+            t = AGraph.edge_label_from_transition_label(t)
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), 8)  # see above

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -10,6 +10,10 @@ import tempfile
 import os
 
 
+def edge_label_from_transition_label(label):
+    return label.split(' [')[0]  # if no condition, label is returned
+
+
 class TestDiagrams(TestCase):
 
     def test_agraph_diagram(self):
@@ -32,7 +36,7 @@ class TestDiagrams(TestCase):
             set(m.states.keys()), set([n.name for n in graph.nodes()]))
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
-            t = AGraph.edge_label_from_transition_label(t)
+            t = edge_label_from_transition_label(t)
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), len(transitions))
@@ -71,7 +75,7 @@ class TestDiagrams(TestCase):
 
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
-            t = AGraph.edge_label_from_transition_label(t)
+            t = edge_label_from_transition_label(t)
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), 8)  # see above
@@ -111,7 +115,7 @@ class TestDiagrams(TestCase):
 
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
-            t = AGraph.edge_label_from_transition_label(t)
+            t = edge_label_from_transition_label(t)
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), 8)  # see above

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -4,6 +4,7 @@ except ImportError:
     pass
 
 from transitions.extensions import MachineFactory
+from transitions.extensions.diagrams import AGraph
 from unittest import TestCase
 import tempfile
 import os
@@ -31,6 +32,7 @@ class TestDiagrams(TestCase):
             set(m.states.keys()), set([n.name for n in graph.nodes()]))
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
+            t = t.split(AGraph.trigger_condition_sep)[0]
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), len(transitions))
@@ -69,6 +71,7 @@ class TestDiagrams(TestCase):
 
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
+            t = t.split(AGraph.trigger_condition_sep)[0]
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), 8)  # see above
@@ -108,6 +111,7 @@ class TestDiagrams(TestCase):
 
         triggers = set([n.attr['label'] for n in graph.edges()])
         for t in triggers:
+            t = t.split(AGraph.trigger_condition_sep)[0]
             self.assertIsNotNone(getattr(m, t))
 
         self.assertEqual(len(graph.edges()), 8)  # see above

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -80,7 +80,7 @@ class AGraph(Diagram):
                     container.add_edge(src, dst, label=lbl)
 
     def _transition_label(self, edge_label, tran):
-        if tran.conditions:
+        if self.machine.show_conditions and tran.conditions:
             return edge_label + AGraph.trigger_condition_sep + '&'.join(
                 c.func if c.target else '!' + c.func
                 for c in tran.conditions
@@ -168,13 +168,15 @@ class MachineGraphSupport(Machine):
         self.set_node_style(self.graph.get_node(self.current_state.name), 'active')
 
     def __init__(self, *args, **kwargs):
-        # remove title from keywords
+        # remove graph config from keywords
         title = kwargs.pop('title', 'State Machine')
+        show_conditions = kwargs.pop('show_conditions', False)
         super(MachineGraphSupport, self).__init__(*args, **kwargs)
 
         # Create graph at beginnning
-        self.graph = self.get_graph(title=title)
+        self.show_conditions = show_conditions
         self.title = title
+        self.graph = self.get_graph(title=title)
 
         # Set initial node as active
         self.set_node_style(self.graph.get_node(self.initial), 'active')

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -74,7 +74,16 @@ class AGraph(Diagram):
                 src = transitions[0]
                 for t in transitions[1]:
                     dst = t.dest
-                    container.add_edge(src, dst, label=label)
+                    lbl = self._transition_label(label, t)
+                    container.add_edge(src, dst, label=lbl)
+
+    def _transition_label(self, edge_label, tran):
+        if tran.conditions:
+            return edge_label + ' / ' + '&'.join(
+                c.func if c.target else '!' + c.func
+                for c in tran.conditions
+            )
+        return edge_label
 
     def get_graph(self, title=None):
         """ Generate a DOT graph with pygraphviz, returns an AGraph object
@@ -141,7 +150,8 @@ class AAGraph(AGraph):
                         dst = dst.get_initial().name
                     else:
                         dst = dst.name
-                    sub.add_edge(src, dst, label=label)
+                    lbl = self._transition_label(label, t)
+                    sub.add_edge(src, dst, label=lbl)
 
 
 class MachineGraphSupport(Machine):

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -77,15 +77,11 @@ class AGraph(Diagram):
                     lbl = self._transition_label(label, t)
                     container.add_edge(src, dst, label=lbl)
 
-    @staticmethod
-    def edge_label_from_transition_label(label):
-        return label.split(' [')[0]  # if no condition, label is returned
-
     def _transition_label(self, edge_label, tran):
         if self.machine.show_conditions and tran.conditions:
             return '{edge_label} [{conditions}]'.format(
                 edge_label=edge_label,
-                conditions='&'.join(
+                conditions=' & '.join(
                     c.func if c.target else '!' + c.func
                     for c in tran.conditions
                 ),

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -18,6 +18,8 @@ class Diagram(object):
 
 class AGraph(Diagram):
 
+    trigger_condition_sep = ' / '
+
     machine_attributes = {
         'directed': True,
         'strict': False,
@@ -79,7 +81,7 @@ class AGraph(Diagram):
 
     def _transition_label(self, edge_label, tran):
         if tran.conditions:
-            return edge_label + ' / ' + '&'.join(
+            return edge_label + AGraph.trigger_condition_sep + '&'.join(
                 c.func if c.target else '!' + c.func
                 for c in tran.conditions
             )

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -18,8 +18,6 @@ class Diagram(object):
 
 class AGraph(Diagram):
 
-    trigger_condition_sep = ' / '
-
     machine_attributes = {
         'directed': True,
         'strict': False,
@@ -79,11 +77,18 @@ class AGraph(Diagram):
                     lbl = self._transition_label(label, t)
                     container.add_edge(src, dst, label=lbl)
 
+    @staticmethod
+    def edge_label_from_transition_label(label):
+        return label.split(' [')[0]  # if no condition, label is returned
+
     def _transition_label(self, edge_label, tran):
         if self.machine.show_conditions and tran.conditions:
-            return edge_label + AGraph.trigger_condition_sep + '&'.join(
-                c.func if c.target else '!' + c.func
-                for c in tran.conditions
+            return '{edge_label} [{conditions}]'.format(
+                edge_label=edge_label,
+                conditions='&'.join(
+                    c.func if c.target else '!' + c.func
+                    for c in tran.conditions
+                ),
             )
         return edge_label
 


### PR DESCRIPTION
On diagrams, change edge label to show the condition, e.g. 'heat / is_flammable'.

Conditions are separated with '&' and "unless conditions" are preceded by '!', e.g. 'heat / !is_flammable & !is_really_hot'.
