### PR TITLE
Fix 'RuntimeError: maximum recursion depth exceeded'

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -532,3 +532,10 @@ class TestTransitions(TestCase):
         # An invalid transition shouldn't execute the callback
         with self.assertRaises(MachineError):
                 m.model.on_exit_A()
+
+    def test_process_trigger(self):
+        m = Machine(states=['raw', 'processed'], initial='raw')
+        m.add_transition('process', 'raw', 'processed')
+
+        m.process()
+        self.assertEqual(m.state, 'processed')

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -222,7 +222,7 @@ class Event(object):
 
     def trigger(self, *args, **kwargs):
         f = partial(self._trigger, *args, **kwargs)
-        return self.machine.process(f)
+        return self.machine._process(f)
 
     def _trigger(self, *args, **kwargs):
         """ Serially execute all transitions that match the current state,
@@ -525,7 +525,7 @@ class Machine(object):
         else:
             func(*event_data.args, **event_data.kwargs)
 
-    def process(self, trigger):
+    def _process(self, trigger):
 
         # default processing
         if not self.has_queue:


### PR DESCRIPTION
When using the word `process` as a trigger a `RuntimeError` exception is raised due to the `process` method calling itself infinitely. Changing the name of the method to `_process` fixes that.