### PR TITLE
Fixes Issues #112 and #113

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.2 (... 2016)
+Release 0.4.2 contain minor API changes:
+- HierarchicalStateMachine.is_state now provides `allow_substates` as an optional argument(thanks to @jonathanunderwood)
+- Machine can now be used in scenarios where multiple inheritance is required (thanks to @jonathanunderwood)
+
 ## 0.4.1 (June, 2016)
 Release 0.4.1 is a minor release containing bug fixes and community feedback:
 - `async` is renamed to `queued` since it describes the mechanism better

--- a/README.md
+++ b/README.md
@@ -846,7 +846,18 @@ machine.state
 ```
 
 Instead of `to_C_3_a()` auto transition is called as `to_C.s3.a()`. If your substate starts with a digit, transitions adds a prefix 's' ('3' becomes 's3') to the auto transition `FunctionWrapper` to comply with the attribute naming scheme of python.
-If interactive completion is not required, `to('C↦3↦a')` can be called directly. Additionally, `on_enter/exit_<<state name>>` is replaced with `on_enter/exit(state_name, callback).
+If interactive completion is not required, `to('C↦3↦a')` can be called directly. Additionally, `on_enter/exit_<<state name>>` is replaced with `on_enter/exit(state_name, callback)`.
+
+To check whether the current state is a substate of a specific state `is_state` supports the keyword `allow_substates`:
+
+```python
+machine.state
+>>> 'C.2.a'
+machine.is_C() # checks for specific states
+>>> False
+machine.is_C(allow_substates=True)
+>>> True
+```
 
 #### Reuse of previously created HSMs
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -217,6 +217,18 @@ class TestTransitions(TestCase):
         s.advance()
         self.assertEquals(s.state, 'C')
 
+        class NewMachine(Machine):
+            def __init__(self, *args, **kwargs):
+                super(NewMachine, self).__init__(*args, **kwargs)
+
+        n = NewMachine(states=states, transitions=[['advance','A','B']], initial='A')
+        self.assertTrue(n.is_A())
+        n.advance()
+        self.assertTrue(n.is_B())
+        with self.assertRaises(MachineError):
+            m = NewMachine(state=['A', 'B'])
+
+
     def test_send_event_data_callbacks(self):
         states = ['A', 'B', 'C', 'D', 'E']
         s = Stuff()
@@ -540,14 +552,3 @@ class TestTransitions(TestCase):
         m.process()
         self.assertEqual(m.state, 'processed')
 
-    def test_inheritance(self):
-        class NewMachine(Machine):
-            def __init__(self, *args, **kwargs):
-                super(NewMachine, self).__init__(*args, **kwargs)
-
-        n = NewMachine(states=['A','B'], transitions=[['advance','A','B']], initial='A')
-        self.assertTrue(n.is_A())
-        n.advance()
-        self.assertTrue(n.is_B())
-        with self.assertRaises(MachineError):
-            m = NewMachine(state=['A', 'B'])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -539,3 +539,15 @@ class TestTransitions(TestCase):
 
         m.process()
         self.assertEqual(m.state, 'processed')
+
+    def test_inheritance(self):
+        class NewMachine(Machine):
+            def __init__(self, *args, **kwargs):
+                super(NewMachine, self).__init__(*args, **kwargs)
+
+        n = NewMachine(states=['A','B'], transitions=[['advance','A','B']], initial='A')
+        self.assertTrue(n.is_A())
+        n.advance()
+        self.assertTrue(n.is_B())
+        with self.assertRaises(MachineError):
+            m = NewMachine(state=['A', 'B'])

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -132,6 +132,8 @@ class TestTransitions(TestsCore):
         self.assertEquals(s.state, 'C')
         s.advance()
         self.assertEquals(s.state, 'C%s2' % State.separator)
+        self.assertFalse(s.is_C())
+        self.assertTrue(s.is_C(allow_substates=True))
 
     def test_use_machine_as_model(self):
         states = ['A', 'B', 'C', 'D']

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -271,7 +271,7 @@ class Machine(object):
     def __init__(self, model=None, states=None, initial=None, transitions=None,
                  send_event=False, auto_transitions=True,
                  ordered_transitions=False, ignore_invalid_triggers=None,
-                 before_state_change=None, after_state_change=None, name=None, queued=False):
+                 before_state_change=None, after_state_change=None, name=None, queued=False, **kwargs):
         """
         Args:
             model (object): The object whose states we want to manage. If None,
@@ -310,7 +310,15 @@ class Machine(object):
                 executed in a state callback function will be queued and executed later.
                 Due to the nature of the queued processing, all transitions will
                 _always_ return True since conditional checks cannot be conducted at queueing time.
+
+            **kwargs additional arguments passed to next class in MRO. This can be ignored in most cases.
         """
+
+        try:
+            super(Machine, self).__init__(**kwargs)
+        except TypeError as e:
+            raise MachineError('Passing arguments {0} caused an inheritance error: {1}'.format(kwargs.keys(), e))
+
         self.model = self if model is None else model
         self.states = OrderedDict()
         self.events = {}

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -143,6 +143,16 @@ class HierarchicalMachine(Machine):
     def _create_state(*args, **kwargs):
         return NestedState(*args, **kwargs)
 
+    def is_state(self, state_name, allow_substates=False):
+        if not allow_substates:
+            return self.current_state.name == state_name
+
+        temp_state = self.current_state
+        while not temp_state.name == state_name and temp_state.level > 0:
+            temp_state = temp_state.parent
+
+        return temp_state.name == state_name
+
     def traverse(self, states, on_enter=None, on_exit=None,
                  ignore_invalid_triggers=None, parent=None, remap={}):
         states = listify(states)


### PR DESCRIPTION
Added a super call in `Machine` (#112) and added optional `allow_substates` argument for `HierarchicalStateMachine.is_state` (#113).

The super call is surrounded with try/except to prevent cryptic `object.__init__() takes no parameters` errors if wrong parameters are passed.