### PR TITLE
Added tox config file for easy multi-environment testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/*
 .coverage
 .ipynb_checkpoints
 examples/state.png
+.tox

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,4 @@
+nose
+mock
 dill
 pygraphviz

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py2, py3
+envlist = py2, py3, codestyle
 skip_missing_interpreters = True
 
 [testenv]
 deps = -rrequirements.txt
        -rrequirements_test.txt
 commands = nosetests
+
+[testenv:codestyle]
+deps = pycodestyle
+commands = pycodestyle --ignore=E501

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py2, py3
+skip_missing_interpreters = True
+
+[testenv]
+deps = -rrequirements.txt
+       -rrequirements_test.txt
+commands = nosetests


### PR DESCRIPTION
This pull-request adds a tox config file that makes it easy to run tests against python2 and python3 in independent virtual environments.

Missing interpreters will be skipped.

It is even possible to run the tests in parallel using detox.