### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# transitions
+# <a name="transitions-module"></a> transitions
 
 A lightweight, object-oriented state machine implementation in Python. Compatible with Python 2.7+ and 3.0+.
 


### PR DESCRIPTION
Even though the link for the Transitions "chapter" was explicitly set to ```transitions```, markdown instead created that link for the name of the module.

So set the link to the module name to ```transitions-module``` and fix the problem.