### PR TITLE
add attribute naming checks to prevent overrides of model.trigger

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -621,11 +621,7 @@ class TestTransitions(TestCase):
 
         model = Model()
         m = Machine(model=model)
-        self.assertTrue(hasattr(model, '_trigger'))
         self.assertEqual(model.trigger(5), 5)
-        model._trigger = lambda x: x
-        m = Machine(model=model)
-        self.assertEqual(model._trigger(5), 5)
 
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -605,6 +605,10 @@ class TestTransitions(TestCase):
         def return_value(value):
             return value
 
+        class Model:
+            def trigger(self):
+                pass
+
         self.stuff.machine.add_transition('do', '*', 'C')
         self.stuff.trigger('do')
         self.assertTrue(self.stuff.is_C())
@@ -614,3 +618,13 @@ class TestTransitions(TestCase):
         self.assertTrue(self.stuff.is_A())
         with self.assertRaises(AttributeError):
             self.stuff.trigger('not_available')
+
+        model = Model()
+        m = Machine(model=model)
+        self.assertTrue(hasattr(model, '_trigger'))
+        model._trigger = lambda x: x
+        m = Machine(model=model)
+        self.assertEqual(model._trigger(5), 5)
+
+
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -606,8 +606,8 @@ class TestTransitions(TestCase):
             return value
 
         class Model:
-            def trigger(self):
-                pass
+            def trigger(self, value):
+                return value
 
         self.stuff.machine.add_transition('do', '*', 'C')
         self.stuff.trigger('do')
@@ -622,6 +622,7 @@ class TestTransitions(TestCase):
         model = Model()
         m = Machine(model=model)
         self.assertTrue(hasattr(model, '_trigger'))
+        self.assertEqual(model.trigger(5), 5)
         model._trigger = lambda x: x
         m = Machine(model=model)
         self.assertEqual(model._trigger(5), 5)

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -377,7 +377,15 @@ class Machine(object):
             self.add_ordered_transitions()
 
         for model in self.models:
-            model.trigger = partial(get_trigger, model)
+            if hasattr(model, 'trigger'):
+                logger.info("%sModel has a attribute called trigger already. Use '_trigger' instead...", self.id)
+                if hasattr(model, '_trigger'):
+                    logger.warn("%sModel already contains attributes 'trigger' and '_trigger'. Skip method binding.",
+                                self.id)
+                else:
+                    model._trigger = partial(get_trigger, model)
+            else:
+                model.trigger = partial(get_trigger, model)
 
     @staticmethod
     def _create_transition(*args, **kwargs):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -378,12 +378,7 @@ class Machine(object):
 
         for model in self.models:
             if hasattr(model, 'trigger'):
-                logger.info("%sModel has a attribute called trigger already. Use '_trigger' instead...", self.id)
-                if hasattr(model, '_trigger'):
-                    logger.warn("%sModel already contains attributes 'trigger' and '_trigger'. Skip method binding.",
-                                self.id)
-                else:
-                    model._trigger = partial(get_trigger, model)
+                logger.info("%sModel already contains an attribute 'trigger'. Skip method binding ", self.id)
             else:
                 model.trigger = partial(get_trigger, model)
 


### PR DESCRIPTION
I added a check whether a model already contains a ‘trigger’ attribute to prevent accidental overriding. 

I am a bit unsure about what a decent ‘plan B’ would be.
My initial idea: Adding ` _trigger` instead.
This would allow a model to change the behaviour of the actual trigger method:

e.g.

```python
class Model:
    def trigger(self, *args, **kwargs):
        if not self._trigger(*args, **kwargs):
            # do something if transition fails
```

This makes default transitions as mentioned by @wtgee easier.
But maybe you have a better idea of how to handle naming collisions in this case. 