### PR TITLE
ensures 'prepare' is handled in the same way as other callbacks

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -159,7 +159,7 @@ class Transition(object):
         machine = event_data.machine
 
         for func in self.prepare:
-            machine._callback(getattr(event_data.model, func), event_data)
+            machine._callback(func, event_data)
             logger.debug("Executed callback '%s' before conditions." % func)
 
         for c in self.conditions:


### PR DESCRIPTION
Closes #149. This just funnels `prepare` calls through `Machine._callback`, same as the other callbacks. @aleneum or @wtgee, feel free to merge, unless there's some reason I'm missing to handle `prepare` differently.