### PR TITLE
allows passing State instances instead of names; closes #153

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,6 +100,16 @@ class TestTransitions(TestCase):
         s.advance()
         self.assertEquals(s.state, 'C')
 
+    def test_pass_state_instances_instead_of_names(self):
+        state_A = State('A')
+        state_B = State('B')
+        states = [state_A, state_B]
+        m = Machine(states=states, initial=state_A)
+        assert m.state == 'A'
+        m.add_transition('advance', state_A, state_B)
+        m.advance()
+        assert m.state == 'B'
+
     def test_conditions(self):
         s = self.stuff
         s.machine.add_transition('advance', 'A', 'B', conditions='this_passes')

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -521,6 +521,7 @@ class Machine(object):
 
         if isinstance(source, string_types):
             source = list(self.states.keys()) if source == '*' else [source]
+        source = [s.name if isinstance(s, State) else s for s in listify(source)]
 
         if self.before_state_change:
             before = listify(before) + listify(self.before_state_change)
@@ -529,6 +530,8 @@ class Machine(object):
             after = listify(after) + listify(self.after_state_change)
 
         for s in source:
+            if isinstance(dest, State):
+                dest = dest.name
             t = self._create_transition(s, dest, conditions, unless, before,
                                         after, prepare, **kwargs)
             self.events[trigger].add_transition(t)

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -521,7 +521,8 @@ class Machine(object):
 
         if isinstance(source, string_types):
             source = list(self.states.keys()) if source == '*' else [source]
-        source = [s.name if isinstance(s, State) else s for s in listify(source)]
+        else:
+            source = [s.name if isinstance(s, State) else s for s in listify(source)]
 
         if self.before_state_change:
             before = listify(before) + listify(self.before_state_change)


### PR DESCRIPTION
Addresses issue in #153--allows `State` instances to be passed in as arguments to `add_transition` instead of requiring strings.