### PR TITLE
Allow injecting lock instance (or any arbitrary context manager) into LockedMachine

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ m.get_triggers('liquid')
 >>> ['evaporate']
 m.get_triggers('plasma')
 >>> []
-# you can also query several states at once 
+# you can also query several states at once
 m.get_triggers('solid', 'liquid', 'gas', 'plasma')
 >>> ['melt', 'evaporate', 'sublimate', 'ionize']
 ```
@@ -644,7 +644,7 @@ lump = Matter()
 machine = Machine(lump, ['solid', 'liquid'], initial='solid')
 machine.add_transition('melt', 'solid', 'liquid', before='set_environment')
 
-lump.melt(45)  # positional arg; 
+lump.melt(45)  # positional arg;
 # equivalent to lump.trigger('melt', 45)
 lump.print_temperature()
 >>> 'Current temperature is 45 degrees celsius.'
@@ -857,9 +857,9 @@ transitions = [
   ['walk', 'standing', 'walking'],
   ['stop', 'walking', 'standing'],
   # this transition will end in 'caffeinated_dithering'...
-  ['drink', '*', 'caffeinated'], 
+  ['drink', '*', 'caffeinated'],
   # ... that is why we do not need do specify 'caffeinated' here anymore
-  ['walk', 'caffeinated_dithering', 'caffeinated_running'], 
+  ['walk', 'caffeinated_dithering', 'caffeinated_running'],
   ['relax', 'caffeinated', 'standing']
 ]
 # ...
@@ -987,6 +987,23 @@ thread = Thread(target=machine.to_B)
 thread.start()
 machine.new_attrib = 42 # not synchronized! will mess with execution order
 ```
+
+Any python context manager can be passed in via the `context` keyword argument:
+
+```python
+from transitions.extensions import LockedMachine as Machine
+from threading import Thread, RLock
+
+states = ['A', 'B', 'C']
+
+lock1 = RLock()
+lock2 = RLock()
+
+machine = Machine(states=states, initial='A', context=[lock1, lock2])
+```
+
+It's important that any user-provided context managers are re-entrant since the state machine will call them multiple
+times, even in the context of a single trigger invocation.
 
 ### <a name="bug-reports"></a>I have a [bug report/issue/question]...
 For bug reports and other issues, please open an issue on GitHub.

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -107,6 +107,43 @@ class TestLockedTransitions(TestCore):
         self.assertAlmostEqual(blocked - begin, 1, delta=0.1)
 
 
+class TestMultipleContexts(TestCore):
+
+    class TestContext(object):
+        def __init__(self, event_list):
+            self._event_list = event_list
+
+        def __enter__(self):
+            self._event_list.append((self, "enter"))
+
+        def __exit__(self, type, value, traceback):
+            self._event_list.append((self, "exit"))
+
+    def setUp(self):
+        self.event_list = []
+
+        self.c1 = self.TestContext(event_list=self.event_list)
+        self.c2 = self.TestContext(event_list=self.event_list)
+
+        self.stuff = Stuff(machine_cls=MachineFactory.get_predefined(locked=True), extra_kwargs={
+            'context': [self.c1, self.c2]
+        })
+        del self.event_list[:]
+
+        self.stuff.machine.add_transition('forward', 'A', 'B')
+
+    def tearDown(self):
+        pass
+
+    def test_ordering(self):
+        self.stuff.forward()
+        # There are a lot of internal enter/exits, but the key is that the outermost are in the expected order
+        self.assertEqual(self.event_list[0], (self.c1, "enter"))
+        self.assertEqual(self.event_list[1], (self.c2, "enter"))
+        self.assertEqual(self.event_list[-2], (self.c2, "exit"))
+        self.assertEqual(self.event_list[-1], (self.c1, "exit"))
+
+
 # Same as TestLockedTransition but with LockedHierarchicalMachine
 class TestLockedHierarchicalTransitions(TestsNested, TestLockedTransitions):
     def setUp(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,12 +3,20 @@ from transitions import Machine
 
 class Stuff(object):
 
-    def __init__(self, states=None, machine_cls=Machine):
+    def __init__(self, states=None, machine_cls=Machine, extra_kwargs={}):
 
         self.state = None
         self.message = None
         states = ['A', 'B', 'C', 'D', 'E', 'F'] if states is None else states
-        self.machine = machine_cls(self, states=states, initial='A', name='Test Machine')
+
+        args = [self]
+        kwargs = {
+            'states': states,
+            'initial': 'A',
+            'name': 'Test Machine',
+        }
+        kwargs.update(extra_kwargs)
+        self.machine = machine_cls(*args, **kwargs)
         self.level = 1
         self.machine_cls = machine_cls
 

--- a/transitions/extensions/locking.py
+++ b/transitions/extensions/locking.py
@@ -1,38 +1,57 @@
-from ..core import Machine, Transition, Event
+from ..core import Machine, Transition, Event, listify
 
 from threading import RLock
 import inspect
 
+try:
+    from contextlib import nested  # Python 2
+except ImportError:
+    from contextlib import ExitStack, contextmanager
+
+    @contextmanager
+    def nested(*contexts):
+        """
+        Reimplementation of nested in python 3.
+        """
+        with ExitStack() as stack:
+            for ctx in contexts:
+                stack.enter_context(ctx)
+            yield contexts
+
 
 class LockedMethod:
 
-    def __init__(self, lock, func):
-        self.lock = lock
+    def __init__(self, context, func):
+        self.context = context
         self.func = func
 
     def __call__(self, *args, **kwargs):
-        with self.lock:
+        with nested(*self.context):
             return self.func(*args, **kwargs)
 
 
 class LockedEvent(Event):
 
     def trigger(self, model, *args, **kwargs):
-        with self.machine.rlock:
+        with nested(*self.machine.context):
             return super(LockedEvent, self).trigger(model, *args, **kwargs)
 
 
 class LockedMachine(Machine):
 
     def __init__(self, *args, **kwargs):
-        self.rlock = RLock()
+        try:
+            self.context = listify(kwargs.pop('context'))
+        except KeyError:
+            self.context = [RLock()]
+
         super(LockedMachine, self).__init__(*args, **kwargs)
 
     def __getattribute__(self, item):
         f = super(LockedMachine, self).__getattribute__
         tmp = f(item)
         if inspect.ismethod(tmp) and item not in "__getattribute__":
-            return LockedMethod(f('rlock'), tmp)
+            return LockedMethod(f('context'), tmp)
         return tmp
 
     def __getattr__(self, item):


### PR DESCRIPTION
Thanks for the great library!

Small addition, to allow specifying a lock instance, or an arbitrary set of managers in LockedMachine.