### PR TITLE
Separate add_models method for core.Machine

### DIFF
--- a/tests/test_add_remove.py
+++ b/tests/test_add_remove.py
@@ -1,0 +1,53 @@
+try:
+    from builtins import object
+except ImportError:
+    pass
+
+from transitions import Machine
+from unittest import TestCase
+
+import gc
+import weakref
+import threading
+
+
+class Dummy(object):
+    pass
+
+
+class TestTransitionsAddRemove(TestCase):
+
+    def test_garbage_collection(self):
+
+        states = ['A', 'B', 'C', 'D', 'E', 'F']
+        machine = Machine(states=states, initial='A', name='Test Machine', add_self=False)
+        machine.add_transition('advance', 'A', 'B')
+        machine.add_transition('advance', 'B', 'C')
+        machine.add_transition('advance', 'C', 'D')
+
+        s1 = Dummy()
+        s2 = Dummy()
+
+        s2_collected = threading.Event()
+        s2_proxy = weakref.proxy(s2, lambda _: s2_collected.set())
+
+        machine.add_model([s1, s2])
+
+        self.assertTrue(s1.is_A())
+        self.assertTrue(s2.is_A())
+        s1.advance()
+
+        self.assertTrue(s1.is_B())
+        self.assertTrue(s2.is_A())
+
+        self.assertFalse(s2_collected.is_set())
+        machine.remove_model(s2)
+        del s2
+        gc.collect()
+        self.assertTrue(s2_collected.is_set())
+
+        s3 = Dummy()
+        machine.add_model(s3)
+        s3.advance()
+        s3.advance()
+        self.assertTrue(s3.is_C())

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -107,7 +107,7 @@ class TestDiagrams(TestCase):
         self.assertEqual(m2.graph.get_node(m1.state).attr['color'],
                          AGraph.style_attributes['node']['default']['color'])
         # backwards compatibility test
-        self.assertEqual(m.get_graph(), m1.get_graph())
+        self.assertTrue(m.get_graph() is m1.get_graph() or m.get_graph() is m2.get_graph())
 
     def test_model_method_collision(self):
         class GraphModel:

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -386,6 +386,7 @@ class Machine(object):
             self.add_model(self)
 
     def add_model(self, model):
+        """ Register a model with the state machine, initializing triggers and callbacks. """
         models = listify(model)
 
         for model in models:
@@ -407,6 +408,8 @@ class Machine(object):
                 self.models.append(model)
 
     def remove_model(self, model):
+        """ Deregister a model with the state machine. The model will still contain all previously added triggers
+        and callbacks, but will not receive updates when states or transitions are added to the Machine. """
         models = listify(model)
 
         for model in models:

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -205,7 +205,7 @@ class GraphMachine(Machine):
     def get_combined_graph(self, title=None, force_new=False):
         logger.info('Returning graph of the first model. In future releases, this ' +
                     'method will return a combined graph of all models.')
-        return self._get_graph(self.models[0], title, force_new)
+        return self._get_graph(next(iter(self.models)), title, force_new)
 
     def set_edge_state(self, graph, edge_from, edge_to, state='default'):
         """ Mark a node as active by changing the attributes """

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -140,8 +140,8 @@ class HierarchicalMachine(Machine):
         self._buffered_transitions = []
         super(HierarchicalMachine, self).__init__(*args, **kwargs)
 
-    def add_models(self, model):
-        super(HierarchicalMachine, self).add_models(model)
+    def add_model(self, model):
+        super(HierarchicalMachine, self).add_model(model)
         models = listify(model)
         for m in models:
             if hasattr(m, 'to'):

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -18,14 +18,17 @@ class FunctionWrapper(object):
             self._func = func
 
     def add(self, func, path):
-        name = path[0]
-        if name[0].isdigit():
-            name = 's' + name
-        if hasattr(self, name):
-            getattr(self, name).add(func, path[1:])
+        if len(path) > 0:
+            name = path[0]
+            if name[0].isdigit():
+                name = 's' + name
+            if hasattr(self, name):
+                getattr(self, name).add(func, path[1:])
+            else:
+                x = FunctionWrapper(func, path[1:])
+                setattr(self, name, x)
         else:
-            x = FunctionWrapper(func, path[1:])
-            setattr(self, name, x)
+            self._func = func
 
     def __call__(self, *args, **kwargs):
         return self._func(*args, **kwargs)
@@ -136,12 +139,16 @@ class HierarchicalMachine(Machine):
     def __init__(self, *args, **kwargs):
         self._buffered_transitions = []
         super(HierarchicalMachine, self).__init__(*args, **kwargs)
-        for model in self.models:
-            if hasattr(model, 'to'):
+
+    def add_models(self, model):
+        super(HierarchicalMachine, self).add_models(model)
+        models = listify(model)
+        for m in models:
+            if hasattr(m, 'to'):
                 logger.warn("%sModel already has a 'to'-method. It will NOT be overwritten by NestedMachine", self.id)
             else:
-                to_func = partial(self.to, model)
-                setattr(model, 'to', to_func)
+                to_func = partial(self.to, m)
+                setattr(m, 'to', to_func)
 
     # Instead of creating transitions directly, Machine now use a factory method which can be overridden
     @staticmethod
@@ -287,24 +294,26 @@ class HierarchicalMachine(Machine):
             source = [x.name for x in self.states.values()] if source == '*' else [source]
 
         # FunctionWrappers are only necessary if a custom separator is used
-        if trigger not in self.events and NestedState.separator not in '_':
+        if trigger not in self.events:
             self.events[trigger] = self._create_event(trigger, self)
-            if trigger.startswith('to_'):
-                path = trigger[3:].split(NestedState.separator)
-                for model in self.models:
-                    trig_func = partial(self.events[trigger].trigger, model)
-                    if hasattr(model, 'to_' + path[0]):
-                        t = getattr(model, 'to_' + path[0])
-                        t.add(trig_func, path[1:])
-                    else:
-                        t = FunctionWrapper(trig_func, path[1:])
-                        setattr(model, 'to_' + path[0], t)
-            else:
-                for model in self.models:
-                    trig_func = partial(self.events[trigger].trigger, model)
-                    setattr(model, trigger, trig_func)
+            for model in self.models:
+                self._add_trigger_to_model(trigger, model)
         super(HierarchicalMachine, self).add_transition(trigger, source, dest, conditions=conditions, unless=unless,
                                                         prepare=prepare, before=before, after=after, **kwargs)
+
+    def _add_trigger_to_model(self, trigger, model):
+        if trigger.startswith('to_') and NestedState.separator != '_':
+            path = trigger[3:].split(NestedState.separator)
+            print(path)
+            trig_func = partial(self.events[trigger].trigger, model)
+            if hasattr(model, 'to_' + path[0]):
+                t = getattr(model, 'to_' + path[0])
+                t.add(trig_func, path[1:])
+            else:
+                t = FunctionWrapper(trig_func, path[1:])
+                setattr(model, 'to_' + path[0], t)
+        else:
+            super(HierarchicalMachine, self)._add_trigger_to_model(trigger, model)
 
     def on_enter(self, state_name, callback):
         self.get_state(state_name).add_callback('enter', callback)


### PR DESCRIPTION
In the interest of having a single(ton) state machine definition apply repeatedly to temporary model instances, I've tried to adapt Machine to allow adding models after the fact. (see #165)

This works fine for the core tests, but appears to break anything nested related, so more work from me is required. If anyone with experience in the 'nested' extension can give some insight, it would be appreciated!