### PR TITLE
Add per-model handling of initial states and locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,40 @@ lump.state
 
 Here you get to consolidate all state machine functionality into your existing model, which often feels more natural way than sticking all of the functionality we want in a separate standalone `Machine` instance.
 
+You can also create a standalone machine, and register models dynamically via `machine.add_model`. Remember to call `machine.remove_model` if machine is long-lasting while your models are temporary and should be garbage collected:
+
+```python
+class Matter():
+    pass
+
+lump1 = Matter()
+lump2 = Matter()
+
+machine = Machine(states=states, transitions=transitions, initial='solid', add_self=False)
+
+machine.add_model(lump1)
+machine.add_model(lump2, initial='liquid')
+
+lump1.state
+>>> 'solid'
+lump2.state
+>>> 'liquid'
+
+machine.remove_model([lump1, lump2])
+del lump1  # lump1 is garbage collected
+del lump2  # lump2 is garbage collected
+```
+
+If you don't provide an initial state in the state machine constructor, you must provide one every time you add a model:
+
+```python
+machine = Machine(states=states, transitions=transitions, add_self=False)
+
+machine.add_model(Matter())
+>>> "MachineError: No initial state configured for machine, must specify when adding model."
+machine.add_model(Matter(), initial='liquid')
+```
+
 ### Logging
 
 Transitions includes very rudimentary logging capabilities. A number of events--namely, state changes, transition triggers, and conditional checks--are logged as INFO-level events using the standard Python `logging` module. This means you can easily configure logging to standard output in a script:
@@ -988,7 +1022,7 @@ thread.start()
 machine.new_attrib = 42 # not synchronized! will mess with execution order
 ```
 
-Any python context manager can be passed in via the `context` keyword argument:
+Any python context manager can be passed in via the `machine_context` keyword argument:
 
 ```python
 from transitions.extensions import LockedMachine as Machine
@@ -999,7 +1033,16 @@ states = ['A', 'B', 'C']
 lock1 = RLock()
 lock2 = RLock()
 
-machine = Machine(states=states, initial='A', context=[lock1, lock2])
+machine = Machine(states=states, initial='A', machine_context=[lock1, lock2])
+```
+
+Any contexts via `machine_model` will be shared between all models registered with the `Machine`.
+Per-model contexts can be added as well:
+
+```
+lock3 = RLock()
+
+machine.add_model(model, model_context=lock3)
 ```
 
 It's important that any user-provided context managers are re-entrant since the state machine will call them multiple

--- a/tests/test_add_remove.py
+++ b/tests/test_add_remove.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     pass
 
-from transitions import Machine
+from transitions import Machine, MachineError
 from unittest import TestCase
 
 import gc
@@ -51,3 +51,51 @@ class TestTransitionsAddRemove(TestCase):
         s3.advance()
         s3.advance()
         self.assertTrue(s3.is_C())
+
+    def test_add_model_initial_state(self):
+        states = ['A', 'B', 'C', 'D', 'E', 'F']
+        machine = Machine(states=states, initial='A', name='Test Machine', add_self=False)
+        machine.add_transition('advance', 'A', 'B')
+        machine.add_transition('advance', 'B', 'C')
+        machine.add_transition('advance', 'C', 'D')
+
+        s1 = Dummy()
+        s2 = Dummy()
+        s3 = Dummy()
+
+        machine.add_model(s1)
+        machine.add_model(s2, initial='B')
+        machine.add_model(s3, initial='C')
+
+        s1.advance()
+        s2.advance()
+        s3.advance()
+
+        self.assertTrue(s1.is_B())
+        self.assertTrue(s2.is_C())
+        self.assertTrue(s3.is_D())
+
+    def test_add_model_no_initial_state(self):
+        states = ['A', 'B', 'C', 'D', 'E', 'F']
+        machine = Machine(states=states, name='Test Machine', add_self=False)
+        machine.add_transition('advance', 'A', 'B')
+        machine.add_transition('advance', 'B', 'C')
+        machine.add_transition('advance', 'C', 'D')
+
+        s1 = Dummy()
+        s2 = Dummy()
+        s3 = Dummy()
+
+        with self.assertRaises(MachineError):
+            machine.add_model(s1)
+        machine.add_model(s1, initial='A')
+        machine.add_model(s2, initial='B')
+        machine.add_model(s3, initial='C')
+
+        s1.advance()
+        s2.advance()
+        s3.advance()
+
+        self.assertTrue(s1.is_B())
+        self.assertTrue(s2.is_C())
+        self.assertTrue(s3.is_D())

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -141,7 +141,7 @@ class TestMultipleContexts(TestCore):
         self.stuff.machine.add_transition('forward', 'A', 'B')
 
     def tearDown(self):
-        pass
+        self.stuff.machine.remove_model(self.s1)
 
     def test_ordering(self):
         self.stuff.forward()

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -52,9 +52,6 @@ class State(object):
         self.on_enter = listify(on_enter) if on_enter else []
         self.on_exit = listify(on_exit) if on_exit else []
 
-    def __str__(self):
-        return self.name
-
     def enter(self, event_data):
         """ Triggered when a state is entered. """
         logger.debug("%sEntering state %s. Processing callbacks...", event_data.machine.id, self.name)

--- a/transitions/extensions/locking.py
+++ b/transitions/extensions/locking.py
@@ -1,7 +1,9 @@
-from ..core import Machine, Transition, Event, listify
+from transitions.core import Machine, Transition, Event, listify
 
+from collections import defaultdict
 from threading import RLock
 import inspect
+import weakref
 
 try:
     from contextlib import nested  # Python 2
@@ -33,7 +35,7 @@ class LockedMethod:
 class LockedEvent(Event):
 
     def trigger(self, model, *args, **kwargs):
-        with nested(*self.machine.context):
+        with nested(*self.machine.model_context_map[model]):
             return super(LockedEvent, self).trigger(model, *args, **kwargs)
 
 
@@ -41,17 +43,47 @@ class LockedMachine(Machine):
 
     def __init__(self, *args, **kwargs):
         try:
-            self.context = listify(kwargs.pop('context'))
+            self.machine_context = listify(kwargs.pop('machine_context'))
         except KeyError:
-            self.context = [RLock()]
+            self.machine_context = [RLock()]
+
+        self.model_context_map = defaultdict(list)
 
         super(LockedMachine, self).__init__(*args, **kwargs)
+
+        if self.machine_context:
+            for model in self.models:
+                self.model_context_map[model].extend(self.machine_context)
+
+    def add_model(self, model, *args, **kwargs):
+        models = listify(model)
+
+        try:
+            model_context = listify(kwargs.pop('model_context'))
+        except KeyError:
+            model_context = []
+
+        output = super(LockedMachine, self).add_model(models, *args, **kwargs)
+
+        for model in models:
+            self.model_context_map[model].extend(self.machine_context)
+            self.model_context_map[model].extend(model_context)
+
+        return output
+
+    def remove_model(self, model):
+        models = listify(model)
+
+        for model in models:
+            del self.model_context_map[model]
+
+        return super(LockedMachine, self).add_model(models, *args, **kwargs)
 
     def __getattribute__(self, item):
         f = super(LockedMachine, self).__getattribute__
         tmp = f(item)
         if inspect.ismethod(tmp) and item not in "__getattribute__":
-            return LockedMethod(f('context'), tmp)
+            return LockedMethod(f('machine_context'), tmp)
         return tmp
 
     def __getattr__(self, item):

--- a/transitions/extensions/locking.py
+++ b/transitions/extensions/locking.py
@@ -71,7 +71,7 @@ class LockedMachine(Machine):
 
         return output
 
-    def remove_model(self, model):
+    def remove_model(self, model, *args, **kwargs):
         models = listify(model)
 
         for model in models:


### PR DESCRIPTION
- Allow not specifying initial state in machine.__init__ when no models are being added
- Allow specifying initial state in machine.add_model, optional when initial specified in init
- Allow specifying per-machine and per-model contexts in LockedMachine. Current default behaviour of one per-machine global RLock() maintained.