### PR TITLE
doc: Improve info about callback execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A lightweight, object-oriented state machine implementation in Python. Compatibl
         - [Queued transitions](#queued-transitions)
         - [Conditional transitions](#conditional-transitions)
         - [Callbacks](#transition-callbacks)
+    - [Execution order](#execution-order)
     - [Passing data](#passing-data)
     - [Alternative initialization patterns](#alternative-initialization-patterns)
     - [Logging](#logging)
@@ -602,12 +603,20 @@ lump.melt()
 
 Note that `prepare` will not be called unless the current state is a valid source for the named transition.
 
+### <a name="execution-order"> Execution order
 In summary, callbacks on transitions are executed in the following order:
 
-* `'prepare'` (executed as soon as the transition starts)
-* `'conditions'` / `'unless'` (conditions *may* fail and halt the transition)
-* `'before'` (executed while the model is still in the source state)
-* `'after'` (executed while the model is in the destination state)
+|      Callback           | Current State |               Comments                        |
+|-------------------------|:-------------:|-----------------------------------------------|
+| `'prepare'`             | `source`      | executed as soon as the transition starts     |
+| `'conditions'/'unless'` | `source`      | conditions *may* fail and halt the transition |
+| `'before'`              | `source`      |                                               |
+| `'machine.before'`      | `source`      | default callbacks declared on model           |
+| `'state.exit'`          | `source`      | callbacks declared on the source state        |
+| `<STATE CHANGE>`        |               |                                               |
+| `'state.enter'`         | `destination` | callbacks declared on the destination state   |
+| `'after'`               | `destination` |                                               |
+| `'machine.after'`       | `destination` | default callbacks declared on model           |
 
 Default actions meant to be executed before or after *every* transition can be passed to `Machine` during initialization with
 `before_state_change` and `after_state_change` respectively:

--- a/README.md
+++ b/README.md
@@ -606,17 +606,18 @@ Note that `prepare` will not be called unless the current state is a valid sourc
 ### <a name="execution-order"> Execution order
 In summary, callbacks on transitions are executed in the following order:
 
-|      Callback           | Current State |               Comments                        |
-|-------------------------|:-------------:|-----------------------------------------------|
-| `'prepare'`             | `source`      | executed as soon as the transition starts     |
-| `'conditions'/'unless'` | `source`      | conditions *may* fail and halt the transition |
-| `'before'`              | `source`      |                                               |
-| `'machine.before'`      | `source`      | default callbacks declared on model           |
-| `'state.exit'`          | `source`      | callbacks declared on the source state        |
-| `<STATE CHANGE>`        |               |                                               |
-| `'state.enter'`         | `destination` | callbacks declared on the destination state   |
-| `'after'`               | `destination` |                                               |
-| `'machine.after'`       | `destination` | default callbacks declared on model           |
+|      Callback             | Current State |               Comments                        |
+|---------------------------|:-------------:|-----------------------------------------------|
+| `'transition.prepare'`    | `source`      | executed as soon as the transition starts     |
+| `'transition.conditions'` | `source`      | conditions *may* fail and halt the transition |
+| `'transition.unless'`     | `source`      | conditions *may* fail and halt the transition |
+| `'transition.before'`     | `source`      |                                               |
+| `'machine.before'`        | `source`      | default callbacks declared on model           |
+| `'state.exit'`            | `source`      | callbacks declared on the source state        |
+| `<STATE CHANGE>`          |               |                                               |
+| `'state.enter'`           | `destination` | callbacks declared on the destination state   |
+| `'transition.after'`      | `destination` |                                               |
+| `'machine.after'`         | `destination` | default callbacks declared on model           |
 
 Default actions meant to be executed before or after *every* transition can be passed to `Machine` during initialization with
 `before_state_change` and `after_state_change` respectively:


### PR DESCRIPTION
The bullets in the README where explained the order of *some* of the callbacks were very helpful, 
but I had to read the code to be sure about the other callbacks involved.
Therefor I made the following enhancements to its contents:


- Converted into a table.
- Promoted as a new section in the contents.
- Added status enter/exit Cbs,;
- Added machine default before/after
- Add section in contents.
- Format as table.