### PR TITLE
fix(test): skip tests relying on *pygraphviz* if not installed

### DIFF
--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -15,7 +15,7 @@ import os
 try:
     ## Just to skip tests if *pygraphviz8 not installed
     import pygraphviz as pgv  # @UnresolvedImport
-except:
+except:  # pragma: no cover
     pgv = None
 
 

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -8,15 +8,22 @@ from .utils import Stuff
 from transitions.extensions import MachineFactory
 from transitions.extensions.diagrams import AGraph, Diagram
 from transitions.extensions.nesting import NestedState
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import tempfile
 import os
+
+try:
+    ## Just to skip tests if *pygraphviz8 not installed
+    import pygraphviz as pgv  # @UnresolvedImport
+except:
+    pgv = None
 
 
 def edge_label_from_transition_label(label):
     return label.split(' | ')[0].split(' [')[0]  # if no condition, label is returned; returns first event only
 
 
+@skipIf(pgv is None, 'AGraph diagram requires pygraphviz')
 class TestDiagrams(TestCase):
 
     def setUp(self):

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -11,6 +11,7 @@ from os.path import getsize
 
 from transitions.extensions import MachineFactory
 from transitions.extensions.nesting import NestedState as State
+from unittest import skipIf
 from .test_core import TestTransitions as TestsCore
 from .utils import Stuff
 
@@ -19,6 +20,11 @@ try:
 except ImportError:
     from mock import MagicMock
 
+try:
+    ## Just to skip tests if *pygraphviz8 not installed
+    import pygraphviz as pgv  # @UnresolvedImport
+except:
+    pgv = None
 
 state_separator = State.separator
 
@@ -453,6 +459,7 @@ class TestTransitions(TestsCore):
         self.assertTrue('relax' in trans)
 
 
+@skipIf(pgv is None, 'AGraph diagram requires pygraphviz')
 class TestWithGraphTransitions(TestTransitions):
 
     def setUp(self):

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -23,7 +23,7 @@ except ImportError:
 try:
     ## Just to skip tests if *pygraphviz8 not installed
     import pygraphviz as pgv  # @UnresolvedImport
-except:
+except:  # pragma: no cover
     pgv = None
 
 state_separator = State.separator

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -9,6 +9,7 @@ import logging
 
 from transitions.extensions import MachineFactory
 from transitions.extensions.nesting import NestedState
+from unittest import skipIf
 from .test_nesting import TestTransitions as TestsNested
 from .test_core import TestTransitions as TestCore
 from .utils import Stuff
@@ -17,6 +18,12 @@ try:
     from unittest.mock import MagicMock
 except ImportError:
     from mock import MagicMock
+
+try:
+    ## Just to skip tests if *pygraphviz8 not installed
+    import pygraphviz as pgv  # @UnresolvedImport
+except:
+    pgv = None
 
 
 logger = logging.getLogger(__name__)
@@ -168,6 +175,7 @@ class TestMultipleContexts(TestCore):
 
 
 # Same as TestLockedTransition but with LockedHierarchicalMachine
+@skipIf(pgv is None, 'AGraph diagram requires pygraphviz')
 class TestLockedHierarchicalTransitions(TestsNested, TestLockedTransitions):
     def setUp(self):
         NestedState.separator = '_'

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -22,7 +22,7 @@ except ImportError:
 try:
     ## Just to skip tests if *pygraphviz8 not installed
     import pygraphviz as pgv  # @UnresolvedImport
-except:
+except:  # pragma: no cover
     pgv = None
 
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -9,7 +9,6 @@ import logging
 
 from transitions.extensions import MachineFactory
 from transitions.extensions.nesting import NestedState
-from unittest import skipIf
 from .test_nesting import TestTransitions as TestsNested
 from .test_core import TestTransitions as TestCore
 from .utils import Stuff
@@ -18,12 +17,6 @@ try:
     from unittest.mock import MagicMock
 except ImportError:
     from mock import MagicMock
-
-try:
-    ## Just to skip tests if *pygraphviz8 not installed
-    import pygraphviz as pgv  # @UnresolvedImport
-except:  # pragma: no cover
-    pgv = None
 
 
 logger = logging.getLogger(__name__)
@@ -175,13 +168,12 @@ class TestMultipleContexts(TestCore):
 
 
 # Same as TestLockedTransition but with LockedHierarchicalMachine
-@skipIf(pgv is None, 'AGraph diagram requires pygraphviz')
 class TestLockedHierarchicalTransitions(TestsNested, TestLockedTransitions):
     def setUp(self):
         NestedState.separator = '_'
         states = ['A', 'B', {'name': 'C', 'children': ['1', '2', {'name': '3', 'children': ['a', 'b', 'c']}]},
                   'D', 'E', 'F']
-        self.stuff = Stuff(states, machine_cls=MachineFactory.get_predefined(locked=True, graph=True, nested=True))
+        self.stuff = Stuff(states, machine_cls=MachineFactory.get_predefined(locked=True, nested=True))
         self.stuff.heavy_processing = heavy_processing
         self.stuff.machine.add_transition('forward', '*', 'B', before='heavy_processing')
 


### PR DESCRIPTION
It simply does not fail when PyGraphiviz is not installed.

This is needed on Windows because there is not yet a *wheel* for python-3.5+