### PR TITLE
feat(core): add __repr__ on basic classes to facilitate debugging

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,11 +5,12 @@ except ImportError:
 
 from .utils import InheritedStuff
 from .utils import Stuff
+import sys
 from transitions import Machine
 from transitions import MachineError
 from transitions import State
 from transitions.core import listify
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import warnings
 warnings.filterwarnings('error', category=PendingDeprecationWarning, message=".*0\.5\.0.*")
 
@@ -649,6 +650,8 @@ class TestTransitions(TestCase):
         # self stuff machine should have to-transitions to every state
         self.assertEqual(len(self.stuff.machine.get_triggers('B')), len(self.stuff.machine.states))
 
+    @skipIf(sys.version_info < (3, ),
+            "String-checking disabled on PY-2 because is different")
     def test_repr(self):
         def a_condition(event_data):
             self.assertRegex(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -649,6 +649,31 @@ class TestTransitions(TestCase):
         # self stuff machine should have to-transitions to every state
         self.assertEqual(len(self.stuff.machine.get_triggers('B')), len(self.stuff.machine.states))
 
+    def test_repr(self):
+        def a_condition(event_data):
+            self.assertRegex(
+                str(event_data.transition.conditions),
+                r"\[<Condition\(<function TestTransitions.test_repr.<locals>"
+                ".a_condition at [^>]+>\)@\d+>\]")
+
+            return True
+
+        def check_repr(event_data):
+            self.assertRegex(
+                str(event_data),
+                r"<EventData\('<State\('A'\)@\d+>', "
+                "<Transition\('A', 'B'\)@\d+>\)@\d+>")
+
+            m.checked = True
+
+        m = Machine(states=['A', 'B'],
+                    before_state_change=check_repr, send_event=True,
+                    initial='A')
+        m.add_transition('do_strcheck', 'A', 'B', conditions=a_condition)
+
+        self.assertTrue(m.do_strcheck())
+        self.assertIn('checked', vars(m))
+
     def test_warning(self):
         import sys
         # does not work with python 3.3. However, the warning is shown when Machine is initialized manually.

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -80,6 +80,9 @@ class State(object):
         callback_list = getattr(self, 'on_' + trigger)
         callback_list.append(func)
 
+    def __repr__(self):
+        return "<%s('%s')@%s>" % (type(self).__name__, self.name, id(self))
+
 
 class Condition(object):
 
@@ -115,6 +118,9 @@ class Condition(object):
         else:
             return predicate(
                 *event_data.args, **event_data.kwargs) == self.target
+
+    def __repr__(self):
+        return "<%s(%s)@%s>" % (type(self).__name__, self.func, id(self))
 
 
 class Transition(object):
@@ -198,6 +204,10 @@ class Transition(object):
         callback_list = getattr(self, trigger)
         callback_list.append(func)
 
+    def __repr__(self):
+        return "<%s('%s', '%s')@%s>" % (type(self).__name__,
+                                        self.source, self.dest, id(self))
+
 
 class EventData(object):
 
@@ -223,6 +233,10 @@ class EventData(object):
     def update(self, model):
         """ Updates the current State to accurately reflect the Machine. """
         self.state = self.machine.get_state(model.state)
+
+    def __repr__(self):
+        return "<%s('%s', %s)@%s>" % (type(self).__name__, self.state,
+                                      getattr(self, 'transition'), id(self))
 
 
 class Event(object):
@@ -277,6 +291,9 @@ class Event(object):
             if t.execute(event):
                 return True
         return False
+
+    def __repr__(self):
+        return "<%s('%s')@%s>" % (type(self).__name__, self.name, id(self))
 
     def add_callback(self, trigger, func):
         """ Add a new before or after callback to all available transitions.
@@ -702,7 +719,7 @@ class Machine(object):
         # Machine.__dict__ does not contain double underscore variables.
         # Class variables will be mangled.
         if name.startswith('__'):
-            raise AttributeError("{} does not exist".format(name))
+            raise AttributeError("'{}' does not exist".format(name))
 
         # Could be a callback
         callback_type, target = self._identify_callback(name)
@@ -718,7 +735,7 @@ class Machine(object):
                 return partial(state.add_callback, callback_type[3:])
 
         # Nothing matched
-        raise AttributeError("{} does not exist".format(name))
+        raise AttributeError("'{}' does not exist on '{}'".format(name, id(self)))
 
 
 class MachineError(Exception):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -719,7 +719,8 @@ class Machine(object):
         # Machine.__dict__ does not contain double underscore variables.
         # Class variables will be mangled.
         if name.startswith('__'):
-            raise AttributeError("'{}' does not exist".format(name))
+            raise AttributeError("'{}' does not exist on <Machine@{}>"
+                                 .format(name, id(self)))
 
         # Could be a callback
         callback_type, target = self._identify_callback(name)
@@ -727,7 +728,8 @@ class Machine(object):
         if callback_type is not None:
             if callback_type in ['before', 'after', 'prepare']:
                 if target not in self.events:
-                    raise MachineError('Event "%s" is not registered.' % target)
+                    raise MachineError("event '{}' is not registered on <Machine@{}>"
+                                       .format(target, id(self)))
                 return partial(self.events[target].add_callback, callback_type)
 
             elif callback_type in ['on_enter', 'on_exit']:
@@ -735,7 +737,7 @@ class Machine(object):
                 return partial(state.add_callback, callback_type[3:])
 
         # Nothing matched
-        raise AttributeError("'{}' does not exist on '{}'".format(name, id(self)))
+        raise AttributeError("'{}' does not exist on <Machine@{}>".format(name, id(self)))
 
 
 class MachineError(Exception):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -83,38 +83,38 @@ class State(object):
 
 class Condition(object):
 
-        def __init__(self, func, target=True):
-            """
-            Args:
-                func (string): Name of the condition-checking callable
-                target (bool): Indicates the target state--i.e., when True,
-                    the condition-checking callback should return True to pass,
-                    and when False, the callback should return False to pass.
-            Notes:
-                This class should not be initialized or called from outside a
-                Transition instance, and exists at module level (rather than
-                nesting under the ransition class) only because of a bug in
-                dill that prevents serialization under Python 2.7.
-            """
-            self.func = func
-            self.target = target
+    def __init__(self, func, target=True):
+        """
+        Args:
+            func (string): Name of the condition-checking callable
+            target (bool): Indicates the target state--i.e., when True,
+                the condition-checking callback should return True to pass,
+                and when False, the callback should return False to pass.
+        Notes:
+            This class should not be initialized or called from outside a
+            Transition instance, and exists at module level (rather than
+            nesting under the ransition class) only because of a bug in
+            dill that prevents serialization under Python 2.7.
+        """
+        self.func = func
+        self.target = target
 
-        def check(self, event_data):
-            """ Check whether the condition passes.
-            Args:
-                event_data (EventData): An EventData instance to pass to the
-                condition (if event sending is enabled) or to extract arguments
-                from (if event sending is disabled). Also contains the data
-                model attached to the current machine which is used to invoke
-                the condition.
-            """
-            predicate = getattr(event_data.model, self.func) if isinstance(self.func, string_types) else self.func
+    def check(self, event_data):
+        """ Check whether the condition passes.
+        Args:
+            event_data (EventData): An EventData instance to pass to the
+            condition (if event sending is enabled) or to extract arguments
+            from (if event sending is disabled). Also contains the data
+            model attached to the current machine which is used to invoke
+            the condition.
+        """
+        predicate = getattr(event_data.model, self.func) if isinstance(self.func, string_types) else self.func
 
-            if event_data.machine.send_event:
-                return predicate(event_data) == self.target
-            else:
-                return predicate(
-                    *event_data.args, **event_data.kwargs) == self.target
+        if event_data.machine.send_event:
+            return predicate(event_data) == self.target
+        else:
+            return predicate(
+                *event_data.args, **event_data.kwargs) == self.target
 
 
 class Transition(object):


### PR DESCRIPTION
Add `__repr--()` methods so that you can debug an app from the log-messages.
The difference can be seen on the `EventData` printout:

- Before:
  ```
    <transitions.core.EventData object at 0x00000275B50534A8>
  ```
- After:
  ```
    <EventData('<State('mailed')@1707857824232>', <Transition('mailed', 'tagged')@1707857837304>)@1707857821880>
  ```