### PR TITLE
feat(core): raise MachineError only for internal-errors

### DIFF
--- a/tests/test_add_remove.py
+++ b/tests/test_add_remove.py
@@ -86,7 +86,7 @@ class TestTransitionsAddRemove(TestCase):
         s2 = Dummy()
         s3 = Dummy()
 
-        with self.assertRaises(MachineError):
+        with self.assertRaises(ValueError):
             machine.add_model(s1)
         machine.add_model(s1, initial='A')
         machine.add_model(s2, initial='B')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -243,7 +243,7 @@ class TestTransitions(TestCase):
         self.assertTrue(n.is_A())
         n.advance()
         self.assertTrue(n.is_B())
-        with self.assertRaises(MachineError):
+        with self.assertRaises(ValueError):
             m = NewMachine(state=['A', 'B'])
 
     def test_send_event_data_callbacks(self):
@@ -333,12 +333,12 @@ class TestTransitions(TestCase):
 
     def test_ordered_transition_error(self):
         m = Machine(states=['A'], initial='A')
-        with self.assertRaises(MachineError):
+        with self.assertRaises(ValueError):
             m.add_ordered_transitions()
         m.add_state('B')
         m.add_ordered_transitions()
         m.add_state('C')
-        with self.assertRaises(MachineError):
+        with self.assertRaises(ValueError):
             m.add_ordered_transitions(['C'])
 
     def test_ignore_invalid_triggers(self):
@@ -472,10 +472,10 @@ class TestTransitions(TestCase):
         callback = m.__getattr__('before_move')
         self.assertTrue(callable(callback))
 
-        with self.assertRaises(MachineError):
+        with self.assertRaises(AttributeError):
             m.__getattr__('before_no_such_transition')
 
-        with self.assertRaises(MachineError):
+        with self.assertRaises(AttributeError):
             m.__getattr__('before_no_such_transition')
 
         with self.assertRaises(AttributeError):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -31,7 +31,7 @@ def get_trigger(model, trigger_name, *args, **kwargs):
     func = getattr(model, trigger_name, None)
     if func:
         return func(*args, **kwargs)
-    raise AttributeError("Model has no trigger named %s" % trigger_name)
+    raise AttributeError("Model has no trigger named '%s'" % trigger_name)
 
 
 class State(object):
@@ -363,7 +363,7 @@ class Machine(object):
         try:
             super(Machine, self).__init__(**kwargs)
         except TypeError as e:
-            raise MachineError('Passing arguments {0} caused an inheritance error: {1}'.format(kwargs.keys(), e))
+            raise ValueError('Passing arguments {0} caused an inheritance error: {1}'.format(kwargs.keys(), e))
 
         self.states = OrderedDict()
         self.events = {}
@@ -388,13 +388,15 @@ class Machine(object):
         if add_self is not True:
             warnings.warn("Starting from transitions version 0.5.0, passing model=None to the "
                           "constructor will no longer add the machine instance as a model but add "
-                          "NO model at all. Consequently, add_self will be removed.", PendingDeprecationWarning)
+                          "NO model at all. Consequently, add_self will be removed.",
+                          PendingDeprecationWarning)
 
         if model and initial is None:
             initial = 'initial'
             warnings.warn("Starting from transitions version 0.5.0, passing initial=None to the constructor "
                           "will no longer create and set the 'initial' state. If no initial"
-                          "state is provided but model is not None, an error will be raised.", PendingDeprecationWarning)
+                          "state is provided but model is not None, an error will be raised.",
+                          PendingDeprecationWarning)
 
         if states is not None:
             self.add_states(states)
@@ -424,7 +426,7 @@ class Machine(object):
 
         if initial is None:
             if self._initial is None:
-                raise MachineError("No initial state configured for machine, must specify when adding model.")
+                raise ValueError("No initial state configured for machine, must specify when adding model.")
             else:
                 initial = self._initial
 
@@ -633,8 +635,8 @@ class Machine(object):
         if states is None:
             states = list(self.states.keys())  # need to listify for Python3
         if len(states) < 2:
-            raise MachineError("Can't create ordered transitions on a Machine "
-                               "with fewer than 2 states.")
+            raise ValueError("Can't create ordered transitions on a Machine "
+                             "with fewer than 2 states.")
         states.remove(self._initial)
         self.add_transition(trigger, self._initial, states[0])
         for i in range(1, len(states)):
@@ -728,8 +730,8 @@ class Machine(object):
         if callback_type is not None:
             if callback_type in ['before', 'after', 'prepare']:
                 if target not in self.events:
-                    raise MachineError("event '{}' is not registered on <Machine@{}>"
-                                       .format(target, id(self)))
+                    raise AttributeError("event '{}' is not registered on <Machine@{}>"
+                                         .format(target, id(self)))
                 return partial(self.events[target].add_callback, callback_type)
 
             elif callback_type in ['on_enter', 'on_exit']:


### PR DESCRIPTION
I change certain e xceptiions from `MachineError` either to:
- `ValueError`, e.g. when they are thrown for contructor arg errors), 
- `AttributeErrors`, when invoking a non-existing trigger on the machine

The purpose is for a Machine clients to handle "dynamic" errors that
denote inability to process transition,
differently from "static" setup/configuration errors.