### PR TITLE
Reflexive state notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A lightweight, object-oriented state machine implementation in Python. Compatibl
     - [Transitions](#transitions)
         - [Automatic transitions](#automatic-transitions-for-all-states)
         - [Transitioning from multiple states](#transitioning-from-multiple-states)
+        - [Reflexive transitions from multiple states](#reflexive-from-multiple-states)
         - [Ordered transitions](#ordered-transitions)
         - [Queued transitions](#queued-transitions)
         - [Conditional transitions](#conditional-transitions)
@@ -441,6 +442,17 @@ machine.add_transition('to_liquid', '*', 'liquid')
 ```
 
 Note that wildcard transitions will only apply to states that exist at the time of the add_transition() call. Calling a wildcard-based transition when the model is in a state added after the transition was defined will elicit an invalid transition message, and will not transition to the target state.
+
+#### <a name="reflexive-from-multiple-states"></a>Transitioning from multiple states
+A reflexive trigger (trigger that has the same state as source and destination) can easily be added specifying `=` as destination.
+This is handy if the same reflexive trigger should be added to multiple states.
+For example:
+
+```python
+machine.add_transition('touch', ['liquid', 'gas', 'plasma'], '=', after='change_shape')
+```
+
+This will add reflexive transitions for all three states with `touch()` as trigger and with `change_shape` executed after each trigger.
 
 #### <a name="ordered-transitions"></a> Ordered transitions
 A common desire is for state transitions to follow a strict linear sequence. For instance, given states `['A', 'B', 'C']`, you might want valid transitions for `A` → `B`, `B` → `C`, and `C` → `A` (but no other pairs).

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -829,3 +829,19 @@ class TestTransitions(TestCase):
         self.stuff.to_C()
         self.stuff.machine.remove_transition('go', dest='D')
         self.assertFalse(hasattr(self.stuff, 'go'))
+
+    def test_reflexive_transition(self):
+        self.stuff.machine.add_transition('reflex', ['A', 'B'], '=', after='increase_level')
+        self.assertEqual(self.stuff.state, 'A')
+        self.stuff.reflex()
+        self.assertEqual(self.stuff.state, 'A')
+        self.assertEqual(self.stuff.level, 2)
+        self.stuff.to_B()
+        self.assertEqual(self.stuff.state, 'B')
+        self.stuff.reflex()
+        self.assertEqual(self.stuff.state, 'B')
+        self.assertEqual(self.stuff.level, 3)
+        self.stuff.to_C()
+        with self.assertRaises(MachineError):
+            self.stuff.reflex()
+        self.assertEqual(self.stuff.level, 3)

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -659,9 +659,13 @@ class Machine(object):
                 model (e.g., passing trigger='advance' will create a new
                 advance() method in the model that triggers the transition.)
             source(string): The name of the source state--i.e., the state we
-                are transitioning away from.
+                are transitioning away from. This can be a single state, a
+                list of states or an asterisk for all states.
             dest (string): The name of the destination State--i.e., the state
-                we are transitioning into.
+                we are transitioning into. This can be a single state or an
+                equal sign to specify that the transition should be reflexive
+                so that the destination will be the same as the source for
+                every given source.
             conditions (string or list): Condition(s) that must pass in order
                 for the transition to take place. Either a list providing the
                 name of a callable, or a list of callables. For the transition

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -686,9 +686,13 @@ class Machine(object):
             source = [s.name if self._has_state(s) else s for s in listify(source)]
 
         for s in source:
-            if self._has_state(dest):
-                dest = dest.name
-            t = self._create_transition(s, dest, conditions, unless, before,
+            if dest == '=':
+                real_dest = s
+            else:
+                real_dest = dest
+            if self._has_state(real_dest):
+                real_dest = real_dest.name
+            t = self._create_transition(s, real_dest, conditions, unless, before,
                                         after, prepare, **kwargs)
             self.events[trigger].add_transition(t)
 


### PR DESCRIPTION
This adds a new notation to specify reflexive states. It is specially handy if you want to specify reflexive transitions for multiple states at once:
```
machine.add_transition('touch', ['liquid', 'gas', 'plasma'], '=', after='change_shape')
```

This would basically add three transitions from the three states using the `touch` trigger with the source state as destination state.