### PR TITLE
Fixed 'to_' transitions on HSM's

### DIFF
--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -180,8 +180,7 @@ class NestedGraph(Graph):
 
         for event in events.values():
             label = str(event.name)
-            if not self.machine.show_auto_transitions and label.startswith('to_') \
-                    and len(event.transitions) == len(self.machine.states):
+            if not self.machine.show_auto_transitions and label.startswith('to_'):
                 continue
 
             for transitions in event.transitions.items():


### PR DESCRIPTION
Have a bug where the 'to_' auto transitions show for nested machines, even when 'show_auto_transitions' is set to false.

Removed equality check for transition events:
... len(event.transitions) == len(self.machine.states)

Seems to make the to_ events get visualised but have no other side effects (I'm sure it was here for a reason, so need some feedback on this change).