### PR TITLE
Fixed auto_transition discovery in diagrams

### DIFF
--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -150,6 +150,13 @@ class TestDiagrams(TestCase):
         self.assertEqual(len(g2.edges()), 4)
         self.assertEqual(len(g2.nodes()), 4)
 
+    def test_trigger_prefixed_with_to_XXX_not_ignored_if_XXX_not_in_states(self):
+        m = self.machine_cls(states=['A', 'B', 'C', 'D'], initial='A', show_auto_transitions=False)
+        m.add_transition('to_end', '*', 'D')
+
+        g = m.get_graph()
+        self.assertEquals(4, len(g.edges()))
+
 
 @skipIf(pgv is None, 'Graph diagram requires pygraphviz')
 class TestDiagramsLocked(TestDiagrams):

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -89,8 +89,7 @@ class Graph(Diagram):
     def _add_edges(self, events, container):
         for event in events.values():
             label = str(event.name)
-            if not self.machine.show_auto_transitions and label.startswith('to_')\
-                    and len(event.transitions) == len(self.machine.states):
+            if self._should_skip_auto_transition(event, label):
                 continue
 
             for transitions in event.transitions.items():
@@ -104,6 +103,16 @@ class Graph(Diagram):
                         edge.attr['label'] = edge.attr['label'] + ' | ' + edge_attr['label']
                     else:
                         container.add_edge(src, dst, **edge_attr)
+
+    def _should_skip_auto_transition(self, event, label):
+        return self._is_auto_transition(event, label) and not self.machine.show_auto_transitions
+
+    def _is_auto_transition(self, event, label):
+        if label.startswith('to_') and len(event.transitions) == len(self.machine.states):
+            state_name = label[len('to_'):]
+            if state_name in self.machine.states:
+                return True
+        return False
 
     def rep(self, f):
         return f.__name__ if callable(f) else f
@@ -180,8 +189,7 @@ class NestedGraph(Graph):
 
         for event in events.values():
             label = str(event.name)
-            if not self.machine.show_auto_transitions and label.startswith('to_') \
-                    and len(event.transitions) == len(self.machine.states):
+            if self._should_skip_auto_transition(event, label):
                 continue
 
             for transitions in event.transitions.items():


### PR DESCRIPTION
This isn't much, but this bug actually happened to me, so I've fixed this for posterity :)

Also, at work I use a slightly older version of your library. When I tried to generate a graph on Windows for "\*" transition (that is: source='\*'), I got an error "KeyError: 'agedge: no key'". I could not reproduce it on my Linux PC. Was this a known bug and I should just update the library or you have no knowledge on that and I should investigate further?