### PR TITLE
Put default value for event data transition `repr` for when transition is not available.

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -252,7 +252,7 @@ class EventData(object):
 
     def __repr__(self):
         return "<%s('%s', %s)@%s>" % (type(self).__name__, self.state,
-                                      getattr(self, 'transition'), id(self))
+                                      getattr(self, 'transition', '[None]'), id(self))
 
 
 class Event(object):


### PR DESCRIPTION
During the machine's `prepare_event` if we were to inspect the state of the `EventData` instance in a debugger, it will break because the `getattr(self, 'transition')` will return an `AttributeError`.

This fix returns a default value for that.

A default value is return so that the format of the `repr` is conserved and will not lead to confusion.
`[None]` is chosen because the transition name may be any sequence of characters and I felt `None` is a token understood by a lot of people. 