### PR TITLE
Removed @staticmethod attribute from _create_* in Machine()

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -501,16 +501,13 @@ class Machine(object):
         for model in models:
             self.models.remove(model)
 
-    @staticmethod
-    def _create_transition(*args, **kwargs):
+    def _create_transition(self, *args, **kwargs):
         return Transition(*args, **kwargs)
 
-    @staticmethod
-    def _create_event(*args, **kwargs):
+    def _create_event(self, *args, **kwargs):
         return Event(*args, **kwargs)
 
-    @staticmethod
-    def _create_state(*args, **kwargs):
+    def _create_state(self, *args, **kwargs):
         return State(*args, **kwargs)
 
     @property

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -381,8 +381,7 @@ class GraphMachine(Machine):
         style_attr = graph.style_attributes.get('graph', {}).get(style)
         item.graph_attr.update(style_attr)
 
-    @staticmethod
-    def _create_transition(*args, **kwargs):
+    def _create_transition(self, *args, **kwargs):
         return TransitionGraphSupport(*args, **kwargs)
 
 

--- a/transitions/extensions/factory.py
+++ b/transitions/extensions/factory.py
@@ -38,15 +38,13 @@ class LockedNestedEvent(LockedEvent, NestedEvent):
 
 class HierarchicalGraphMachine(GraphMachine, HierarchicalMachine):
 
-    @staticmethod
-    def _create_transition(*args, **kwargs):
+    def _create_transition(self, *args, **kwargs):
         return NestedGraphTransition(*args, **kwargs)
 
 
 class LockedHierarchicalMachine(LockedMachine, HierarchicalMachine):
 
-    @staticmethod
-    def _create_event(*args, **kwargs):
+    def _create_event(self, *args, **kwargs):
         return LockedNestedEvent(*args, **kwargs)
 
 
@@ -56,10 +54,8 @@ class LockedGraphMachine(GraphMachine, LockedMachine):
 
 class LockedHierarchicalGraphMachine(GraphMachine, LockedMachine, HierarchicalMachine):
 
-    @staticmethod
-    def _create_transition(*args, **kwargs):
+    def _create_transition(self, *args, **kwargs):
         return NestedGraphTransition(*args, **kwargs)
 
-    @staticmethod
-    def _create_event(*args, **kwargs):
+    def _create_event(self, *args, **kwargs):
         return LockedNestedEvent(*args, **kwargs)

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -175,16 +175,13 @@ class HierarchicalMachine(Machine):
                 setattr(m, 'to', to_func)
 
     # Instead of creating transitions directly, Machine now use a factory method which can be overridden
-    @staticmethod
-    def _create_transition(*args, **kwargs):
+    def _create_transition(self, *args, **kwargs):
         return NestedTransition(*args, **kwargs)
 
-    @staticmethod
-    def _create_event(*args, **kwargs):
+    def _create_event(self, *args, **kwargs):
         return NestedEvent(*args, **kwargs)
 
-    @staticmethod
-    def _create_state(*args, **kwargs):
+    def _create_state(self, *args, **kwargs):
         return NestedState(*args, **kwargs)
 
     def is_state(self, state_name, model, allow_substates=False):


### PR DESCRIPTION
I removed @staticmethod attributes from _create_event, _create_transition, _create_state. It is more flexible that way and no transitions code needs change. My only worry is client code of other library clients.

My rationale: you may need an ability to pass instance variable to your derived event or transition. Quick example:

```
class BookKeeper(object):
  def __init__(self):
    self.events_triggered=0
    self.transitions_taken_place=0

class BookKeepingEvent(Event):
  def __init__(self, book_keeper):
    self.book_keeper=book_keeper
  def trigger(self):
    self.book_keeper.increment_events_triggered()
    super(BookKeepingEvent, self).trigger()

class BookKeepingMachine(Machine):
  def __init__(self):
    self.book_keeper = BookKeeper()
  def _create_event(self):
    return BookKeepingEvent(self.book_keeper)
(...)
```