### PR TITLE
Argument matching for callbacks added

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -406,6 +406,57 @@ class TestTransitions(TestCase):
         self.assertTrue(m.before_state_change[0].called)
         self.assertTrue(m.after_state_change[0].called)
 
+    def test_machine_matches_event_data_to_callback_signature(self):
+        class TestModel(object):
+            def __init__(self):
+                self.b_mock = MagicMock()
+                self.c_mock = MagicMock()
+
+            def on_enter_B(self):
+                self.b_mock()
+
+            def on_enter_C(self):
+                self.c_mock()
+            
+            def on_enter_D(self, a, b):
+                self.a = a
+                self.b = b
+
+            def on_enter_E(self, *args):
+                self.args = args
+
+            def on_enter_F(self, **kwargs):
+                self.kwargs = kwargs
+
+        model = TestModel()
+        m = Machine(model, states=['A', 'B', 'C', 'D', 'E', 'F'], initial='A', auto_transitions=False)
+        m.add_transition('trigger', 'A', 'B')
+        m.add_transition('kwargs_trigger', 'B', 'C')
+        m.add_transition('mixed_trigger', 'C', 'D')
+        m.add_transition('args_trigger', 'D', 'E')
+        m.add_transition('final_trigger', 'E', 'F')
+        m.on_enter_B('on_enter_B')
+        m.on_enter_C('on_enter_C')
+        m.on_enter_D('on_enter_D')
+        m.on_enter_E('on_enter_E')
+        m.on_enter_F('on_enter_F')
+
+        model.trigger('arg1')
+        self.assertTrue(model.b_mock.called)
+
+        model.kwargs_trigger(a=1, b=2)
+        self.assertTrue(model.c_mock.called)
+        
+        model.mixed_trigger(1, c=15, b=20)
+        self.assertEquals(1, model.a)
+        self.assertEquals(20, model.b)
+        
+        model.args_trigger(1, 2, 3, 4, 5, a=15)
+        self.assertEquals(5, len(model.args))
+
+        model.final_trigger(1, 2, 3, b=15, c=20)
+        self.assertEquals(2, len(model.kwargs))
+
     def test_pickle(self):
         import sys
         if sys.version_info < (3, 4):


### PR DESCRIPTION
This was bugging me for a while.
Say I have an trigger and not all callbacks need its arguments (especially conditions, like):
```
class Model(object):
  states = ['unbroken', 'broken']
  def __init__(self, is_concrete=True):
    self.is_concrete = is_concrete
    self.machine = Machine(model=self, (...))
    self.machine.add_transition('hit_hammer', 'unbroken', 'broken',
           conditions='was_hit_hard', unless='is_concrete')
  def was_hit_hard(self, force):
    return force > 50
  def is_concrete(self):
    return self.is_concrete

model.hit_hammer(force=50)
```
. Now the code crashes and I had to resort to changing callback signature to take (\*args, \*\*kwargs), but I would like to avoid that.