### PR TITLE
Argument matching for callbacks added

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -406,6 +406,59 @@ class TestTransitions(TestCase):
         self.assertTrue(m.before_state_change[0].called)
         self.assertTrue(m.after_state_change[0].called)
 
+    def test_machine_matches_event_data_to_callback_signature(self):
+        class TestModel(object):
+            def __init__(self):
+                self.b_mock = MagicMock()
+                self.c_mock = MagicMock()
+
+            def false_condition(self):
+                return False
+            
+            def on_enter_B(self):
+                self.b_mock()
+
+            def on_enter_C(self):
+                self.c_mock()
+            
+            def on_enter_D(self, a, b):
+                self.a = a
+                self.b = b
+
+            def on_enter_E(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        model = TestModel()
+        m = Machine(model, states=['A', 'B', 'C', 'D', 'E', 'F'], initial='A', auto_transitions=False)
+        m.add_transition('trigger', 'A', 'B')
+        m.add_transition('kwargs_trigger', 'B', 'C')
+        m.add_transition('mixed_trigger', 'C', 'D')
+        m.add_transition('args_trigger', 'D', 'E')
+        m.add_transition('final_trigger', 'E', 'F', conditions='false_condition')
+        m.on_enter_B('on_enter_B')
+        m.on_enter_C('on_enter_C')
+        m.on_enter_D('on_enter_D')
+        m.on_enter_E('on_enter_E')
+
+        model.trigger('arg1')
+        self.assertTrue(model.b_mock.called)
+
+        model.kwargs_trigger(a=1, b=2)
+        self.assertTrue(model.c_mock.called)
+        
+        model.mixed_trigger(1, c=15, b=20)
+        self.assertEquals(1, model.a)
+        self.assertEquals(20, model.b)
+        
+        model.args_trigger(1, 2, 3, 4, 5, a=15, c=20)
+        self.assertEquals(5, len(model.args))
+        self.assertEquals(2, len(model.kwargs))
+
+        model.final_trigger(1, 2, c=15)
+        self.assertNotEquals('F', model.state)
+        
+
     def test_pickle(self):
         import sys
         if sys.version_info < (3, 4):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -1,3 +1,4 @@
+import types
 try:
     from builtins import object
 except ImportError:
@@ -130,8 +131,8 @@ class Condition(object):
         if event_data.machine.send_event:
             return predicate(event_data) == self.target
         else:
-            return predicate(
-                *event_data.args, **event_data.kwargs) == self.target
+            args_to_pass, kwargs_to_pass = event_data.trim_event_data_args_to_func_signature(predicate)
+            return predicate(*args_to_pass, **kwargs_to_pass) == self.target
 
     def __repr__(self):
         return "<%s(%s)@%s>" % (type(self).__name__, self.func, id(self))
@@ -250,6 +251,40 @@ class EventData(object):
     def update(self, model):
         """ Updates the current State to accurately reflect the Machine. """
         self.state = self.machine.get_state(model.state)
+
+    def trim_event_data_args_to_func_signature(self, func):
+        if not (inspect.isfunction(func) or inspect.ismethod(func)):
+            return self.args, self.kwargs
+
+        func_args, func_varargs, func_keywords, _ = inspect.getargspec(func)
+
+        if inspect.ismethod(func):
+            func_args.pop(0)
+
+        func_args, args_to_pass = self._get_positional_arguments(func_args, func_varargs)
+        kwargs_to_pass = self._get_keyword_arguments(func_args, func_keywords)
+
+        return args_to_pass, kwargs_to_pass
+
+    def _get_positional_arguments(self, func_args, func_varargs):
+        if func_varargs:
+            args_to_pass = self.args
+        else:
+            number_of_positional_args = min(len(self.args), len(func_args))
+            func_args = func_args[number_of_positional_args:]
+            args_to_pass = self.args[:number_of_positional_args]
+        return func_args, args_to_pass
+
+    def _get_keyword_arguments(self, func_args, func_keywords):
+        if func_keywords:
+            kwargs_to_pass = self.kwargs
+        else:
+            kwargs_to_pass = {}
+            for arg in func_args:
+                if arg in self.kwargs.keys():
+                    kwargs_to_pass[arg] = self.kwargs[arg]
+
+        return kwargs_to_pass
 
     def __repr__(self):
         return "<%s('%s', %s)@%s>" % (type(self).__name__, self.state,
@@ -812,7 +847,8 @@ class Machine(object):
         if self.send_event:
             func(event_data)
         else:
-            func(*event_data.args, **event_data.kwargs)
+            args_to_pass, kwargs_to_pass = event_data.trim_event_data_args_to_func_signature(func)
+            func(*args_to_pass, **kwargs_to_pass)
 
     def _has_state(self, s):
         if isinstance(s, State):


### PR DESCRIPTION
Let me copy my previous post here. I made sure conditions are also covered by argument matching mechanism.

This was bugging me for a while.
Say I have an trigger and not all callbacks need its arguments (especially conditions, like):
```
class Model(object):
  states = ['unbroken', 'broken']
  def __init__(self, is_concrete=True):
    self.is_concrete = is_concrete
    self.machine = Machine(model=self, (...))
    self.machine.add_transition('hit_hammer', 'unbroken', 'broken',
           conditions='was_hit_hard', unless='is_concrete')
  def was_hit_hard(self, force):
    return force > 50
  def is_concrete(self):
    return self.is_concrete

model.hit_hammer(force=50)
```
Now the code crashes and I had to resort to changing callback signature to take (*args, **kwargs), but I would like to avoid that.