### PR TITLE
Don't set global warnings module state

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -14,7 +14,6 @@ from functools import partial
 from six import string_types
 
 import warnings
-warnings.simplefilter('default')
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
I am trying to use transitions for an existing django project. The warnings.simplefilter('default') line is modifying the state of warnings module globally and causing logspew. 